### PR TITLE
Strip hyphens from some resource names

### DIFF
--- a/container-registry.tf
+++ b/container-registry.tf
@@ -1,7 +1,7 @@
 resource "azurerm_container_registry" "acr" {
   count = local.enable_container_registry ? 1 : 0
 
-  name                = local.resource_prefix
+  name                = replace(local.resource_prefix, "-", "")
   resource_group_name = azurerm_resource_group.default.name
   location            = azurerm_resource_group.default.location
   sku                 = "Standard"


### PR DESCRIPTION
* If `environment` or `project_name` contain hyphens, some resources won't launch