### PR TITLE
Allow specifying Redis Cache version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ module "azure_container_apps_hosting" {
   mssql_database_name         = "mydatabase"
 
   enable_redis_cache              = true
+  redis_cache_version             = 6
   redis_cache_family              = "C"
   redis_cache_sku                 = "Basic"
   redis_cache_capacity            = 0
@@ -170,6 +171,7 @@ module "azure_container_apps_hosting" {
 | <a name="input_redis_cache_patch_schedule_day"></a> [redis\_cache\_patch\_schedule\_day](#input\_redis\_cache\_patch\_schedule\_day) | Redis Cache patch schedule day | `string` | `"Wednesday"` | no |
 | <a name="input_redis_cache_patch_schedule_hour"></a> [redis\_cache\_patch\_schedule\_hour](#input\_redis\_cache\_patch\_schedule\_hour) | Redis Cache patch schedule hour | `number` | `18` | no |
 | <a name="input_redis_cache_sku"></a> [redis\_cache\_sku](#input\_redis\_cache\_sku) | Redis Cache SKU | `string` | `"Basic"` | no |
+| <a name="input_redis_cache_version"></a> [redis\_cache\_version](#input\_redis\_cache\_version) | Redis Cache version | `number` | `6` | no |
 | <a name="input_registry_password"></a> [registry\_password](#input\_registry\_password) | Container registry password (required if `enable_container_registry` is false) | `string` | `""` | no |
 | <a name="input_registry_server"></a> [registry\_server](#input\_registry\_server) | Container registry server (required if `enable_container_registry` is false) | `string` | `""` | no |
 | <a name="input_registry_username"></a> [registry\_username](#input\_registry\_username) | Container registry username (required if `enable_container_registry` is false) | `string` | `""` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -26,6 +26,7 @@ locals {
   mssql_max_size_gb                        = var.mssql_max_size_gb
   mssql_database_name                      = var.mssql_database_name
   enable_redis_cache                       = var.enable_redis_cache
+  redis_cache_version                      = var.redis_cache_version
   redis_cache_family                       = var.redis_cache_family
   redis_cache_sku                          = var.redis_cache_sku
   redis_cache_capacity                     = var.redis_cache_capacity

--- a/redis-cache.tf
+++ b/redis-cache.tf
@@ -7,6 +7,7 @@ resource "azurerm_redis_cache" "default" {
   capacity            = local.redis_cache_capacity
   family              = local.redis_cache_family
   sku_name            = local.redis_cache_sku
+  redis_version       = local.redis_cache_version
   enable_non_ssl_port = false
   minimum_tls_version = "1.2"
   public_network_access_enabled = local.launch_in_vnet ? (

--- a/variables.tf
+++ b/variables.tf
@@ -133,6 +133,12 @@ variable "redis_cache_patch_schedule_hour" {
   default     = 18
 }
 
+variable "redis_cache_version" {
+  description = "Redis Cache version"
+  type        = number
+  default     = 6
+}
+
 variable "image_name" {
   description = "Image name"
   type        = string


### PR DESCRIPTION
* Redis cache defaults to version 4, which is mostly out of date.