### PR TITLE
Fix CDN certification validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ module "azure_container_apps_hosting" {
 | [azurerm_cdn_frontdoor_rule.redirect](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
 | [azurerm_cdn_frontdoor_rule_set.redirects](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry) | resource |
+| [azurerm_dns_a_record.frontdoor_custom_domain](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_a_record) | resource |
+| [azurerm_dns_txt_record.frontdoor_custom_domain](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_txt_record) | resource |
 | [azurerm_dns_zone.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_zone) | resource |
 | [azurerm_log_analytics_workspace.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_mssql_database.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_database) | resource |

--- a/dns.tf
+++ b/dns.tf
@@ -21,3 +21,26 @@ resource "azurerm_dns_zone" "default" {
 
   tags = local.tags
 }
+
+resource "azurerm_dns_txt_record" "frontdoor_custom_domain" {
+  for_each = local.cdn_frontdoor_custom_domain_dns_names
+
+  name                = trim(join(".", ["_dnsauth", each.value]), ".")
+  zone_name           = azurerm_dns_zone.default[0].name
+  resource_group_name = local.resource_group.name
+  ttl                 = 3600
+
+  record {
+    value = azurerm_cdn_frontdoor_custom_domain.custom_domain["${each.value}${local.dns_zone_domain_name}"].validation_token
+  }
+}
+
+resource "azurerm_dns_a_record" "frontdoor_custom_domain" {
+  for_each = local.cdn_frontdoor_custom_domain_dns_names
+
+  name                = trim(each.value, ".") == "" ? "@" : trim(each.value, ".")
+  zone_name           = azurerm_dns_zone.default[0].name
+  resource_group_name = local.resource_group.name
+  ttl                 = 300
+  target_resource_id  = azurerm_cdn_frontdoor_endpoint.endpoint[0].id
+}

--- a/locals.tf
+++ b/locals.tf
@@ -52,7 +52,10 @@ locals {
   cdn_frontdoor_response_timeout           = var.cdn_frontdoor_response_timeout
   cdn_frontdoor_custom_domains             = var.cdn_frontdoor_custom_domains
   cdn_frontdoor_host_redirects             = var.cdn_frontdoor_host_redirects
-  ruleset_redirects_id                     = length(local.cdn_frontdoor_host_redirects) > 0 ? [azurerm_cdn_frontdoor_rule_set.redirects[0].id] : []
-  ruleset_ids                              = local.ruleset_redirects_id
-  tagging_command                          = "timeout 15m ${path.module}/script/apply-tags-to-container-app-env-mc-resource-group -n \"${azapi_resource.container_app_env.name}\" -r \"${local.resource_group.name}\" -t \"${replace(jsonencode(local.tags), "\"", "\\\"")}\""
+  cdn_frontdoor_custom_domain_dns_names = local.enable_cdn_frontdoor && local.enable_dns_zone ? toset([
+    for domain in local.cdn_frontdoor_custom_domains : replace(domain, local.dns_zone_domain_name, "") if endswith(domain, local.dns_zone_domain_name)
+  ]) : []
+  ruleset_redirects_id = length(local.cdn_frontdoor_host_redirects) > 0 ? [azurerm_cdn_frontdoor_rule_set.redirects[0].id] : []
+  ruleset_ids          = local.ruleset_redirects_id
+  tagging_command      = "timeout 15m ${path.module}/script/apply-tags-to-container-app-env-mc-resource-group -n \"${azapi_resource.container_app_env.name}\" -r \"${local.resource_group.name}\" -t \"${replace(jsonencode(local.tags), "\"", "\\\"")}\""
 }


### PR DESCRIPTION
* Even though the DNS zone has been specified in the custom domain, the TXT record still needs to be added for it to complete validation automatically. It appears that adding the DNS zone to the custom domain, just gives you the option to click a button to automatically create the record through the Azure Portal