### PR TITLE
Conditionally enable Network Watcher NSG flow logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,14 @@ module "azure_container_apps_hosting" {
 | [azurerm_eventhub_namespace.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventhub_namespace) | resource |
 | [azurerm_log_analytics_data_export_rule.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_data_export_rule) | resource |
 | [azurerm_log_analytics_workspace.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
+| [azurerm_log_analytics_workspace.default_network_watcher_nsg_flow_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_mssql_database.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_database) | resource |
 | [azurerm_mssql_database_extended_auditing_policy.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_database_extended_auditing_policy) | resource |
 | [azurerm_mssql_server.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_server) | resource |
 | [azurerm_mssql_server_extended_auditing_policy.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_server_extended_auditing_policy) | resource |
 | [azurerm_network_security_group.container_apps_infra_allow_frontdoor_inbound_only](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
+| [azurerm_network_watcher.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_watcher) | resource |
+| [azurerm_network_watcher_flow_log.default_network_watcher_nsg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_watcher_flow_log) | resource |
 | [azurerm_private_dns_a_record.mssql_private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_dns_a_record.redis_cache_private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_dns_zone.mssql_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
@@ -155,6 +158,7 @@ module "azure_container_apps_hosting" {
 | [azurerm_redis_firewall_rule.container_app_worker_static_ip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_firewall_rule) | resource |
 | [azurerm_resource_group.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_route_table.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route_table) | resource |
+| [azurerm_storage_account.default_network_watcher_nsg_flow_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 | [azurerm_storage_account.mssql_security_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 | [azurerm_subnet.container_apps_infra_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_subnet.container_instances_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
@@ -205,6 +209,8 @@ module "azure_container_apps_hosting" {
 | <a name="input_enable_event_hub"></a> [enable\_event\_hub](#input\_enable\_event\_hub) | Send Azure Container App logs to an Event Hub sink | `bool` | `false` | no |
 | <a name="input_enable_logstash_consumer"></a> [enable\_logstash\_consumer](#input\_enable\_logstash\_consumer) | Create an Event Hub consumer group for Logstash | `bool` | `false` | no |
 | <a name="input_enable_mssql_database"></a> [enable\_mssql\_database](#input\_enable\_mssql\_database) | Set to true to create an Azure SQL server/database, with a private endpoint within the virtual network | `bool` | `false` | no |
+| <a name="input_enable_network_watcher"></a> [enable\_network\_watcher](#input\_enable\_network\_watcher) | Enable network watcher, with NSG Flow Logs | `bool` | `true` | no |
+| <a name="input_enable_network_watcher_traffic_analytics"></a> [enable\_network\_watcher\_traffic\_analytics](#input\_enable\_network\_watcher\_traffic\_analytics) | Enable network watcher traffic analytics (Requires `enable_network_watcher` to be true) | `bool` | `true` | no |
 | <a name="input_enable_redis_cache"></a> [enable\_redis\_cache](#input\_enable\_redis\_cache) | Set to true to create an Azure Redis Cache, with a private endpoint within the virtual network | `bool` | `false` | no |
 | <a name="input_enable_worker_container"></a> [enable\_worker\_container](#input\_enable\_worker\_container) | Conditionally launch a worker container. This container uses the same image and environment variables as the default container app, but allows a different container command to be run. The worker container does not expose any ports. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |
@@ -217,6 +223,8 @@ module "azure_container_apps_hosting" {
 | <a name="input_mssql_max_size_gb"></a> [mssql\_max\_size\_gb](#input\_mssql\_max\_size\_gb) | The max size of the database in gigabytes | `number` | `2` | no |
 | <a name="input_mssql_server_admin_password"></a> [mssql\_server\_admin\_password](#input\_mssql\_server\_admin\_password) | The administrator password for the MSSQL server. Must be set if `enable_mssql_database` is true | `string` | `""` | no |
 | <a name="input_mssql_sku_name"></a> [mssql\_sku\_name](#input\_mssql\_sku\_name) | Specifies the name of the SKU used by the database | `string` | `"Basic"` | no |
+| <a name="input_network_watcher_retention"></a> [network\_watcher\_retention](#input\_network\_watcher\_retention) | Number of days to retain logs. Set to 0 to keep all logs. | `number` | `90` | no |
+| <a name="input_network_watcher_traffic_analytics_interval"></a> [network\_watcher\_traffic\_analytics\_interval](#input\_network\_watcher\_traffic\_analytics\_interval) | Interval in minutes for Traffic Analytics. | `number` | `60` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_redis_cache_capacity"></a> [redis\_cache\_capacity](#input\_redis\_cache\_capacity) | Redis Cache Capacity | `number` | `0` | no |
 | <a name="input_redis_cache_family"></a> [redis\_cache\_family](#input\_redis\_cache\_family) | Redis Cache family | `string` | `"C"` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -66,13 +66,21 @@ locals {
     local.ruleset_add_response_headers_id,
     local.ruleset_remove_response_headers_id,
   )
-  cdn_frontdoor_enable_rate_limiting              = var.cdn_frontdoor_enable_rate_limiting
-  cdn_frontdoor_rate_limiting_duration_in_minutes = var.cdn_frontdoor_rate_limiting_duration_in_minutes
-  cdn_frontdoor_rate_limiting_threshold           = var.cdn_frontdoor_rate_limiting_threshold
-  cdn_frontdoor_enable_waf                        = local.enable_cdn_frontdoor && local.cdn_frontdoor_enable_rate_limiting
-  cdn_frontdoor_waf_mode                          = var.cdn_frontdoor_waf_mode
-  cdn_frontdoor_rate_limiting_bypass_ip_list      = var.cdn_frontdoor_rate_limiting_bypass_ip_list
-  enable_event_hub                                = var.enable_event_hub
-  enable_logstash_consumer                        = var.enable_logstash_consumer
-  tagging_command                                 = "timeout 15m ${path.module}/script/apply-tags-to-container-app-env-mc-resource-group -n \"${azapi_resource.container_app_env.name}\" -r \"${local.resource_group.name}\" -t \"${replace(jsonencode(local.tags), "\"", "\\\"")}\""
+  cdn_frontdoor_enable_rate_limiting                                          = var.cdn_frontdoor_enable_rate_limiting
+  cdn_frontdoor_rate_limiting_duration_in_minutes                             = var.cdn_frontdoor_rate_limiting_duration_in_minutes
+  cdn_frontdoor_rate_limiting_threshold                                       = var.cdn_frontdoor_rate_limiting_threshold
+  cdn_frontdoor_enable_waf                                                    = local.enable_cdn_frontdoor && local.cdn_frontdoor_enable_rate_limiting
+  cdn_frontdoor_waf_mode                                                      = var.cdn_frontdoor_waf_mode
+  cdn_frontdoor_rate_limiting_bypass_ip_list                                  = var.cdn_frontdoor_rate_limiting_bypass_ip_list
+  enable_event_hub                                                            = var.enable_event_hub
+  enable_logstash_consumer                                                    = var.enable_logstash_consumer
+  enable_network_watcher                                                      = var.enable_network_watcher
+  network_watcher_retention                                                   = var.network_watcher_retention
+  enable_network_watcher_traffic_analytics                                    = var.enable_network_watcher_traffic_analytics
+  network_watcher_traffic_analytics_interval                                  = var.network_watcher_traffic_analytics_interval
+  network_security_group_container_apps_infra_allow_frontdoor_inbound_only_id = local.launch_in_vnet && local.restrict_container_apps_to_cdn_inbound_only && local.enable_cdn_frontdoor ? azurerm_network_security_group.container_apps_infra_allow_frontdoor_inbound_only[0].id : []
+  network_security_group_ids = concat(
+    local.network_security_group_container_apps_infra_allow_frontdoor_inbound_only_id,
+  )
+  tagging_command = "timeout 15m ${path.module}/script/apply-tags-to-container-app-env-mc-resource-group -n \"${azapi_resource.container_app_env.name}\" -r \"${local.resource_group.name}\" -t \"${replace(jsonencode(local.tags), "\"", "\\\"")}\""
 }

--- a/network-watcher.tf
+++ b/network-watcher.tf
@@ -1,0 +1,65 @@
+resource "azurerm_network_watcher" "default" {
+  count = local.enable_network_watcher ? 1 : 0
+
+  name                = "${local.resource_prefix}default"
+  location            = local.resource_group.location
+  resource_group_name = local.resource_group.name
+
+  tags = local.tags
+}
+
+resource "azurerm_storage_account" "default_network_watcher_nsg_flow_logs" {
+  count = local.enable_network_watcher ? 1 : 0
+
+  name                      = "${local.resource_prefix}nwnsgdefault"
+  resource_group_name       = local.resource_group.location
+  location                  = local.resource_group.name
+  account_tier              = "Standard"
+  account_kind              = "StorageV2"
+  account_replication_type  = "LRS"
+  min_tls_version           = "TLS1_2"
+  enable_https_traffic_only = true
+
+  tags = local.tags
+}
+
+resource "azurerm_log_analytics_workspace" "default_network_watcher_nsg_flow_logs" {
+  count = local.enable_network_watcher && local.enable_network_watcher_traffic_analytics ? 1 : 0
+
+  name                = "${local.resource_prefix}nwnsgdefault"
+  location            = local.resource_group.location
+  resource_group_name = local.resource_group.name
+  sku                 = "PerGB2018"
+
+  tags = local.tags
+}
+
+resource "azurerm_network_watcher_flow_log" "default_network_watcher_nsg" {
+  for_each = local.enable_network_watcher ? local.network_security_group_ids : []
+
+  network_watcher_name = azurerm_network_watcher.default[0].name
+  resource_group_name  = azurerm_resource_group.default[0].name
+  name                 = "${local.resource_prefix}nsg${each.value}"
+
+  network_security_group_id = each.value
+  storage_account_id        = azurerm_storage_account.default_network_watcher_nsg_flow_logs[0].id
+  enabled                   = true
+
+  retention_policy {
+    enabled = local.network_watcher_retention == 0 ? false : true
+    days    = local.network_watcher_retention
+  }
+
+  dynamic "traffic_analytics" {
+    for_each = local.enable_network_watcher && local.enable_network_watcher_traffic_analytics ? [0] : []
+    content {
+      enabled               = true
+      workspace_id          = azurerm_log_analytics_workspace.default_network_watcher_nsg_flow_logs[0].workspace_id
+      workspace_region      = azurerm_log_analytics_workspace.default_network_watcher_nsg_flow_logs[0].location
+      workspace_resource_id = azurerm_log_analytics_workspace.default_network_watcher_nsg_flow_logs[0].id
+      interval_in_minutes   = local.network_watcher_traffic_analytics_interval
+    }
+  }
+
+  tags = local.tags
+}

--- a/variables.tf
+++ b/variables.tf
@@ -318,3 +318,27 @@ variable "enable_logstash_consumer" {
   type        = bool
   default     = false
 }
+
+variable "enable_network_watcher" {
+  description = "Enable network watcher, with NSG Flow Logs"
+  type        = bool
+  default     = true
+}
+
+variable "network_watcher_retention" {
+  description = "Number of days to retain logs. Set to 0 to keep all logs."
+  type        = number
+  default     = 90
+}
+
+variable "enable_network_watcher_traffic_analytics" {
+  description = "Enable network watcher traffic analytics (Requires `enable_network_watcher` to be true)"
+  type        = bool
+  default     = true
+}
+
+variable "network_watcher_traffic_analytics_interval" {
+  description = "Interval in minutes for Traffic Analytics."
+  type        = number
+  default     = 60
+}


### PR DESCRIPTION
* Allows creating a Network Watcher, with Network Security Group Flow Logs
* Currently the only NSG is for the Container App. Any further ones created, can be added to the list `network_security_group_ids` in locals, which will then create a flow log for that too
* Allows conditionally enabling Traffic Analytics