### PR TITLE
Revise Alert Rules for App Insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ module "azure_container_apps_hosting" {
 | [azurerm_monitor_metric_alert.count](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.cpu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.http](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_metric_alert.latency](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.memory](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.redis-load](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_mssql_database.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_database) | resource |
@@ -211,6 +212,7 @@ module "azure_container_apps_hosting" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alarm_cpu_threshold_percentage"></a> [alarm\_cpu\_threshold\_percentage](#input\_alarm\_cpu\_threshold\_percentage) | Specify a number (%) which should be set as a threshold for a CPU usage monitoring alarm | `number` | `80` | no |
+| <a name="input_alarm_latency_threshold_ms"></a> [alarm\_latency\_threshold\_ms](#input\_alarm\_latency\_threshold\_ms) | Specify a number in milliseconds which should be set as a threshold for a request latency monitoring alarm | `number` | `1000` | no |
 | <a name="input_alarm_memory_threshold_percentage"></a> [alarm\_memory\_threshold\_percentage](#input\_alarm\_memory\_threshold\_percentage) | Specify a number (%) which should be set as a threshold for a memory usage monitoring alarm | `number` | `80` | no |
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Azure location in which to launch resources. | `string` | n/a | yes |
 | <a name="input_cdn_frontdoor_custom_domains"></a> [cdn\_frontdoor\_custom\_domains](#input\_cdn\_frontdoor\_custom\_domains) | Azure CDN Front Door custom domains. If they are within the DNS zone (optionally created), the Validation TXT records and ALIAS/CNAME records will be created | `list(string)` | `[]` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -85,6 +85,7 @@ locals {
   monitor_endpoint_healthcheck                                                = var.monitor_endpoint_healthcheck
   alarm_cpu_threshold_percentage                                              = var.alarm_cpu_threshold_percentage
   alarm_memory_threshold_percentage                                           = var.alarm_memory_threshold_percentage
+  alarm_latency_threshold_ms                                                  = var.alarm_latency_threshold_ms
   enable_network_watcher                                                      = var.enable_network_watcher
   existing_network_watcher_name                                               = var.existing_network_watcher_name
   existing_network_watcher_resource_group_name                                = var.existing_network_watcher_resource_group_name

--- a/monitor.tf
+++ b/monitor.tf
@@ -17,7 +17,7 @@ resource "azurerm_monitor_action_group" "main" {
   }
 
   dynamic "event_hub_receiver" {
-    for_each = local.enable_event_hub ? [0] : null
+    for_each = local.enable_event_hub ? [0] : []
 
     content {
       name                    = "Event Hub"

--- a/monitor.tf
+++ b/monitor.tf
@@ -73,11 +73,12 @@ resource "azurerm_monitor_metric_alert" "cpu" {
   description         = "Action will be triggered when CPU usage is higher than a defined threshold for longer than 5 minutes"
   window_size         = "PT5M"
   frequency           = "PT5M"
+  severity            = 2
 
   criteria {
     metric_namespace = "microsoft.app/containerapps"
     metric_name      = "UsageNanoCores"
-    aggregation      = "Total"
+    aggregation      = "Average"
     operator         = "GreaterThan"
     # CPU usage in nanocores (1,000,000,000 nanocores = 1 core)
     threshold = ((local.container_cpu * 10000000) * local.alarm_cpu_threshold_percentage)
@@ -98,6 +99,7 @@ resource "azurerm_monitor_metric_alert" "memory" {
   description         = "Action will be triggered when memory usage is higher than a defined threshold for longer than 5 minutes"
   window_size         = "PT5M"
   frequency           = "PT5M"
+  severity            = 2
 
   criteria {
     metric_namespace = "microsoft.app/containerapps"
@@ -124,6 +126,7 @@ resource "azurerm_monitor_metric_alert" "http" {
   # https://github.com/hashicorp/terraform-provider-azurerm/issues/8551
   scopes      = [azurerm_application_insights_standard_web_test.main[0].id, azurerm_application_insights.main[0].id]
   description = "Action will be triggered when regional availability becomes impacted."
+  severity    = 2
 
   application_insights_web_test_location_availability_criteria {
     web_test_id           = azurerm_application_insights_standard_web_test.main[0].id
@@ -147,6 +150,7 @@ resource "azurerm_monitor_metric_alert" "count" {
   description         = "Action will be triggered when container count is zero"
   window_size         = "PT5M"
   frequency           = "PT1M"
+  severity            = 1
 
   criteria {
     metric_namespace = "microsoft.app/containerapps"
@@ -172,6 +176,7 @@ resource "azurerm_monitor_metric_alert" "redis-load" {
   description         = "Action will be triggered when Redis Server Load is high"
   window_size         = "PT5M"
   frequency           = "PT1M"
+  severity            = 2
 
   criteria {
     metric_namespace = "Microsoft.Cache/Redis"

--- a/monitor.tf
+++ b/monitor.tf
@@ -211,7 +211,7 @@ resource "azurerm_monitor_metric_alert" "latency" {
     aggregation      = "Average"
     operator         = "GreaterThan"
     # 1,000ms = 1s
-    threshold = 500
+    threshold = local.alarm_latency_threshold_ms
   }
 
   action {

--- a/variables.tf
+++ b/variables.tf
@@ -385,6 +385,12 @@ variable "alarm_memory_threshold_percentage" {
   default     = 80
 }
 
+variable "alarm_latency_threshold_ms" {
+  description = "Specify a number in milliseconds which should be set as a threshold for a request latency monitoring alarm"
+  type        = number
+  default     = 1000
+}
+
 variable "enable_network_watcher" {
   description = "Enable network watcher. Note: only 1 network watcher per subscription can be created."
   type        = bool


### PR DESCRIPTION
**Add**
- Add latency monitor for Azure Front Door

**Fix**
- Correctly sets severity of existing alerts

**Changes**
- Removes the word "container" from the App Insights instance as it's not contextually correct