### PR TITLE
Deploy Logic App workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,13 @@ module "azure_container_apps_hosting" {
   # Monitoring is disabled by default. If enabled, the following metrics will be monitored:
   # Container App: CPU usage, Memory usage, Revision count, HTTP regional availability
   # Redis (if enabled): Server Load Average
-  enable_monitoring = true
-  monitor_email_receivers = [ "list@email.com" ]
-  monitor_endpoint_healthcheck = "/healthcheck"
-  alarm_cpu_threshold_percentage = 80
+  enable_monitoring                 = true
+  monitor_email_receivers           = [ "list@email.com" ]
+  monitor_endpoint_healthcheck      = "/healthcheck"
+  monitor_enable_slack_webhook      = true
+  monitor_slack_webhook_receiver    = "https://hooks.slack.com/services/xxx/xxx/xxx"
+  monitor_slack_channel             = "channel-name-or-id"
+  alarm_cpu_threshold_percentage    = 80
   alarm_memory_threshold_percentage = 80
 
   # Note that only 1 network watcher can be created within a subscription
@@ -163,6 +166,9 @@ module "azure_container_apps_hosting" {
 | [azurerm_log_analytics_data_export_rule.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_data_export_rule) | resource |
 | [azurerm_log_analytics_workspace.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_log_analytics_workspace.default_network_watcher_nsg_flow_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
+| [azurerm_logic_app_action_http.slack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_http) | resource |
+| [azurerm_logic_app_trigger_http_request.webhook](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_trigger_http_request) | resource |
+| [azurerm_logic_app_workflow.webhook](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_workflow) | resource |
 | [azurerm_monitor_action_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
 | [azurerm_monitor_metric_alert.count](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.cpu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
@@ -269,7 +275,10 @@ module "azure_container_apps_hosting" {
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Image tag | `string` | `"latest"` | no |
 | <a name="input_launch_in_vnet"></a> [launch\_in\_vnet](#input\_launch\_in\_vnet) | Conditionally launch into a VNet | `bool` | `true` | no |
 | <a name="input_monitor_email_receivers"></a> [monitor\_email\_receivers](#input\_monitor\_email\_receivers) | A list of email addresses that should be notified by monitoring alerts | `list(string)` | `[]` | no |
+| <a name="input_monitor_enable_slack_webhook"></a> [monitor\_enable\_slack\_webhook](#input\_monitor\_enable\_slack\_webhook) | Enable slack webhooks to send monitoring notifications to a channel | `bool` | `false` | no |
 | <a name="input_monitor_endpoint_healthcheck"></a> [monitor\_endpoint\_healthcheck](#input\_monitor\_endpoint\_healthcheck) | Specify a route that should be monitored for a 200 OK status | `string` | `"/"` | no |
+| <a name="input_monitor_slack_channel"></a> [monitor\_slack\_channel](#input\_monitor\_slack\_channel) | Slack channel name/id to send messages to | `string` | `""` | no |
+| <a name="input_monitor_slack_webhook_receiver"></a> [monitor\_slack\_webhook\_receiver](#input\_monitor\_slack\_webhook\_receiver) | A Slack App webhook URL | `string` | `""` | no |
 | <a name="input_mssql_database_name"></a> [mssql\_database\_name](#input\_mssql\_database\_name) | The name of the MSSQL database to create. Must be set if `enable_mssql_database` is true | `string` | `""` | no |
 | <a name="input_mssql_max_size_gb"></a> [mssql\_max\_size\_gb](#input\_mssql\_max\_size\_gb) | The max size of the database in gigabytes | `number` | `2` | no |
 | <a name="input_mssql_server_admin_password"></a> [mssql\_server\_admin\_password](#input\_mssql\_server\_admin\_password) | The administrator password for the MSSQL server. Must be set if `enable_mssql_database` is true | `string` | `""` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -96,6 +96,9 @@ locals {
       local.monitor_worker_container_id,
     )
   )
+  monitor_enable_slack_webhook                                                = var.monitor_enable_slack_webhook
+  monitor_slack_webhook_receiver                                              = var.monitor_slack_webhook_receiver
+  monitor_slack_channel                                                       = var.monitor_slack_channel
   alarm_cpu_threshold_percentage                                              = var.alarm_cpu_threshold_percentage
   alarm_memory_threshold_percentage                                           = var.alarm_memory_threshold_percentage
   alarm_latency_threshold_ms                                                  = var.alarm_latency_threshold_ms

--- a/logic-app.tf
+++ b/logic-app.tf
@@ -1,0 +1,43 @@
+resource "azurerm_logic_app_workflow" "webhook" {
+  count = local.enable_monitoring ? 1 : 0
+
+  name                = "${local.resource_prefix}-webhook-workflow"
+  location            = local.resource_group.location
+  resource_group_name = local.resource_group.name
+
+  tags = local.tags
+}
+
+resource "azurerm_logic_app_trigger_http_request" "webhook" {
+  depends_on = [
+    azurerm_logic_app_workflow.webhook[0]
+  ]
+
+  name         = "${local.resource_prefix}-trigger"
+  logic_app_id = azurerm_logic_app_workflow.webhook[0].id
+
+  schema = templatefile("${path.module}/schema/common-alert-schema.json", {})
+}
+
+resource "azurerm_logic_app_action_http" "slack" {
+  count = local.monitor_enable_slack_webhook && length(local.monitor_slack_webhook_receiver) > 0 ? 1 : 0
+
+  depends_on = [
+    azurerm_logic_app_workflow.webhook[0]
+  ]
+
+  name         = "${local.resource_prefix}-action"
+  logic_app_id = azurerm_logic_app_workflow.webhook[0].id
+  method       = "POST"
+  uri          = local.monitor_slack_webhook_receiver
+  headers = {
+    "Content-Type" : "application/json"
+  }
+
+  body = templatefile(
+    "${path.module}/webhook/slack.json",
+    {
+      channel = local.monitor_slack_channel
+    }
+  )
+}

--- a/monitor.tf
+++ b/monitor.tf
@@ -64,6 +64,17 @@ resource "azurerm_monitor_action_group" "main" {
       use_common_alert_schema = true
     }
   }
+
+  dynamic "logic_app_receiver" {
+    for_each = length(azurerm_logic_app_workflow.webhook[0].id) > 0 ? [0] : []
+
+    content {
+      name                    = "Logic App"
+      resource_id             = azurerm_logic_app_workflow.webhook[0].id
+      callback_url            = azurerm_logic_app_trigger_http_request.webhook.callback_url
+      use_common_alert_schema = true
+    }
+  }
 }
 
 resource "azurerm_monitor_metric_alert" "cpu" {

--- a/schema/common-alert-schema.json
+++ b/schema/common-alert-schema.json
@@ -1,0 +1,64 @@
+{
+  "properties": {
+    "data": {
+      "properties": {
+        "alertContext": {
+          "properties": {},
+          "type": "object"
+        },
+        "essentials": {
+          "properties": {
+            "alertContextVersion": {
+              "type": "string"
+            },
+            "alertId": {
+              "type": "string"
+            },
+            "alertRule": {
+              "type": "string"
+            },
+            "alertTargetIDs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "description": {
+              "type": "string"
+            },
+            "essentialsVersion": {
+              "type": "string"
+            },
+            "firedDateTime": {
+              "type": "string"
+            },
+            "monitorCondition": {
+              "type": "string"
+            },
+            "monitoringService": {
+              "type": "string"
+            },
+            "originAlertId": {
+              "type": "string"
+            },
+            "resolvedDateTime": {
+              "type": "string"
+            },
+            "severity": {
+              "type": "string"
+            },
+            "signalType": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "schemaId": {
+      "type": "string"
+    }
+  },
+  "type": "object"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -397,6 +397,24 @@ variable "monitor_email_receivers" {
   default     = []
 }
 
+variable "monitor_enable_slack_webhook" {
+  description = "Enable slack webhooks to send monitoring notifications to a channel"
+  type        = bool
+  default     = false
+}
+
+variable "monitor_slack_webhook_receiver" {
+  description = "A Slack App webhook URL"
+  type        = string
+  default     = ""
+}
+
+variable "monitor_slack_channel" {
+  description = "Slack channel name/id to send messages to"
+  type        = string
+  default     = ""
+}
+
 variable "monitor_endpoint_healthcheck" {
   description = "Specify a route that should be monitored for a 200 OK status"
   type        = string

--- a/webhook/slack.json
+++ b/webhook/slack.json
@@ -1,0 +1,71 @@
+{
+  "channel": "${channel}",
+  "text": "@{triggerBody()?['data']?['essentials']?['alertRule']}: @{triggerBody()?['data']?['essentials']?['description']}",
+  "blocks": [
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "<!here>"
+      }
+    }
+  ],
+  "attachments": [
+    {
+      "color": "#FF0000",
+      "blocks": [
+        {
+          "type": "header",
+          "text": {
+            "type": "plain_text",
+            "text": "@{triggerBody()?['data']?['essentials']?['alertRule']}"
+          }
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "_@{triggerBody()?['data']?['essentials']?['description']}_"
+          }
+        },
+        {
+          "type": "section",
+          "fields": [
+            {
+              "type": "mrkdwn",
+              "text": "*Severity*"
+            },
+            {
+              "type": "plain_text",
+              "text": "@{triggerBody()?['data']?['essentials']?['severity']}"
+            },
+            {
+              "type": "mrkdwn",
+              "text": "*Metric definition*"
+            },
+            {
+              "type": "plain_text",
+              "text": "@{triggerBody()?['data']?['alarmContext']?['condition']?['allOf']?[0]?['metricName']} @{triggerBody()?['data']?['alarmContext']?['condition']?['allOf']?[0]?['operator']} @{triggerBody()?['data']?['alarmContext']?['condition']?['allOf']?[0]?['threshold']}"
+            },
+            {
+              "type": "mrkdwn",
+              "text": "*Metric value recorded*"
+            },
+            {
+              "type": "plain_text",
+              "text": "@{triggerBody()?['data']?['alarmContext']?['condition']?['allOf']?[0]?['metricValue']} "
+            },
+            {
+              "type": "mrkdwn",
+              "text": "*Alarm status*"
+            },
+            {
+              "type": "plain_text",
+              "text": "@{triggerBody()?['data']?['essentials']?['monitorCondition']} "
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Conditionally deploy Logic App Workflow, and subscribe it to an Alert Group so that it can be triggered by Alert Rule notifications.
- Set up a HTTP Request action for the Workflow, which takes the payload from the Alert Rule defined in the [Common Alert Schema](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-common-schema) and creates a rich-text Slack compatible payload to POST to a provided Slack Webhook.

