### PR TITLE
Switched revision mode to Multiple if min replicas > 1

### DIFF
--- a/container-app.tf
+++ b/container-app.tf
@@ -36,6 +36,7 @@ resource "azapi_resource" "default" {
     properties : {
       managedEnvironmentId = azapi_resource.container_app_env.id
       configuration = {
+        activeRevisionsMode = local.container_min_replicas > 1 ? "Multiple" : "Single"
         ingress = {
           external   = true
           targetPort = local.container_port


### PR DESCRIPTION
Fixes #79 
>[Microsoft.App/ContainerApps](https://learn.microsoft.com/en-us/azure/templates/microsoft.app/2022-03-01/containerapps?pivots=deployment-language-terraform#configuration-2):-
`ActiveRevisionsMode` controls how active revisions are handled for the Container app:
>
>Multiple: multiple revisions can be active.
>Single: Only one revision can be active at a time. Revision weights can not be used in this mode. If no value if provided, this is the default.
