### PR TITLE
Ensure web test is enabled

### DIFF
--- a/monitor.tf
+++ b/monitor.tf
@@ -16,6 +16,8 @@ resource "azurerm_application_insights_standard_web_test" "main" {
   location                = local.resource_group.location
   application_insights_id = azurerm_application_insights.main.id
   timeout                 = 10
+  description             = "Regional HTTP availability check"
+  enabled                 = true
 
   geo_locations = [
     "emea-se-sto-edge", # UK West


### PR DESCRIPTION
By default, the Web Test resource is deployed but not actively monitoring. Setting `enabled` to `true` ensures metrics get recorded into App Insights