### PR TITLE
Automatically include App Insights Connection

### DIFF
--- a/container-app.tf
+++ b/container-app.tf
@@ -45,6 +45,14 @@ resource "azapi_resource" "default" {
           {
             "name" : "acr-password",
             "value" : local.registry_password
+          },
+          {
+            "name" : "applicationinsights--connectionstring",
+            "value" : azurerm_application_insights.main.connection_string
+          },
+          {
+            "name" : "applicationinsights--instrumentationkey",
+            "value" : azurerm_application_insights.main.instrumentation_key
           }
           ],
           [
@@ -81,11 +89,22 @@ resource "azapi_resource" "default" {
                 }
               }
             ] : []
-            env = concat([
-              for env_name, env_value in local.container_environment_variables : {
-                name  = env_name
-                value = env_value
-              }
+            env = concat(
+              [
+                {
+                  "name" : "ApplicationInsights__ConnectionString",
+                  "secretRef" : "applicationinsights--connectionstring"
+                },
+                {
+                  "name" : "ApplicationInsights__InstrumentationKey",
+                  "secretRef" : "applicationinsights--instrumentationkey"
+                }
+              ],
+              [
+                for env_name, env_value in local.container_environment_variables : {
+                  name  = env_name
+                  value = env_value
+                }
               ],
               [
                 for env_name, env_value in local.container_secret_environment_variables : {

--- a/monitor.tf
+++ b/monitor.tf
@@ -29,7 +29,10 @@ resource "azurerm_application_insights_standard_web_test" "main" {
     url = local.enable_cdn_frontdoor ? "https://${azurerm_cdn_frontdoor_endpoint.endpoint[0].host_name}${local.monitor_endpoint_healthcheck}" : "https://${jsondecode(azapi_resource.default.output).properties.configuration.ingress.fqdn}${local.monitor_endpoint_healthcheck}"
   }
 
-  tags = local.tags
+  tags = merge(
+    local.tags,
+    { "hidden-link:${azurerm_application_insights.main.id}" = "Resource" },
+  )
 }
 
 resource "azurerm_monitor_action_group" "main" {


### PR DESCRIPTION
- Add the App Insights `InstrumentationKey` and `ConnectionString` into the Container Secrets and Environment variables for digestion by dotnet apps.
- Adds the `hidden-link` tag to the Web Test to retain the link to App Insights