### PR TITLE
Scale rule names must be lowercase and cannot contain spaces

### DIFF
--- a/container-app.tf
+++ b/container-app.tf
@@ -118,7 +118,7 @@ resource "azapi_resource" "default" {
           maxReplicas = local.container_max_replicas
           rules = [
             {
-              name = "Concurrent HTTP Requests",
+              name = "concurrent-http-requests",
               http = {
                 metadata = {
                   concurrentRequests = local.container_scale_rule_concurrent_request_count
@@ -127,7 +127,7 @@ resource "azapi_resource" "default" {
             },
             local.container_scale_rule_scale_down_out_of_hours ?
             {
-              name = "Outside of normal operating hours",
+              name = "outside-of-normal-operating-hours",
               custom = {
                 type = "cron"
                 metadata = {


### PR DESCRIPTION
Fixes deployment of Scale Rules issue:
```
--------------------------------------------------------------------------------
│ RESPONSE 400: 400 Bad Request
│ ERROR CODE: ContainerAppInvalidPropertyValue
│ --------------------------------------------------------------------------------
│ {
│   "error": {
│     "code": "ContainerAppInvalidPropertyValue",
│     "message": "Property 'rules.name' has an invalid value 'Concurrent HTTP Requests'. A value must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character."
│   }
│ }
```