### PR TITLE
set minReplicas to 1 to prevent a scale-down to 0

### DIFF
--- a/container-app.tf
+++ b/container-app.tf
@@ -207,6 +207,9 @@ resource "azapi_resource" "worker" {
             ])
           }
         ]
+        scale = {
+          minReplicas = 1
+        }
       }
     }
   })


### PR DESCRIPTION
`minReplicas` for the Worker container default to `null` which means, because the Worker container has no ingress traffic or liveness probes, it will always scale to zero.

This change is a safety precaution to ensure the worker container always stays alive by setting the `minReplicas` to `1`.