### PR TITLE
Only create workflow steps if monitoring is enabled

### DIFF
--- a/logic-app.tf
+++ b/logic-app.tf
@@ -9,6 +9,8 @@ resource "azurerm_logic_app_workflow" "webhook" {
 }
 
 resource "azurerm_logic_app_trigger_http_request" "webhook" {
+  count = local.enable_monitoring ? 1 : 0
+
   depends_on = [
     azurerm_logic_app_workflow.webhook[0]
   ]
@@ -20,7 +22,7 @@ resource "azurerm_logic_app_trigger_http_request" "webhook" {
 }
 
 resource "azurerm_logic_app_action_http" "slack" {
-  count = local.monitor_enable_slack_webhook && length(local.monitor_slack_webhook_receiver) > 0 ? 1 : 0
+  count = local.enable_monitoring && local.monitor_enable_slack_webhook && length(local.monitor_slack_webhook_receiver) > 0 ? 1 : 0
 
   depends_on = [
     azurerm_logic_app_workflow.webhook[0]


### PR DESCRIPTION
If `enable_monitoring` was set to `false`, both the trigger and action resources would still try to be created, but they depend on the Logic App Workflow being built, which would only happen if `enable_monitoring` is `true`, causing a break and an error during a `terraform apply` due to dependencies not being met.

This PR adds the same conditional check for the trigger and action