### PR TITLE
Fix monitor container ids

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -88,13 +88,11 @@ locals {
   enable_monitoring                               = var.enable_monitoring
   monitor_email_receivers                         = var.monitor_email_receivers
   monitor_endpoint_healthcheck                    = var.monitor_endpoint_healthcheck
-  monitor_default_container_id                    = [azapi_resource.default.id]
-  monitor_worker_container_id                     = local.enable_worker_container ? [azapi_resource.worker[0].id] : []
-  monitor_container_ids = toset(
-    concat(
-      local.monitor_default_container_id,
-      local.monitor_worker_container_id,
-    )
+  monitor_default_container_id                    = { "default_id" = azapi_resource.default.id }
+  monitor_worker_container_id                     = local.enable_worker_container ? { "worker_id" = azapi_resource.worker[0].id } : {}
+  monitor_container_ids = merge(
+    local.monitor_default_container_id,
+    local.monitor_worker_container_id,
   )
   monitor_enable_slack_webhook                                                = var.monitor_enable_slack_webhook
   monitor_slack_webhook_receiver                                              = var.monitor_slack_webhook_receiver

--- a/monitor.tf
+++ b/monitor.tf
@@ -78,9 +78,7 @@ resource "azurerm_monitor_action_group" "main" {
 }
 
 resource "azurerm_monitor_metric_alert" "cpu" {
-  for_each = local.enable_monitoring ? (
-    length(local.monitor_container_ids) > 1 ? local.monitor_container_ids : toset(local.monitor_default_container_id)
-  ) : []
+  for_each = local.enable_monitoring ? local.monitor_container_ids : {}
 
   name                = "${element(split("/", each.value), length(split("/", each.value)) - 1)}-cpu"
   resource_group_name = local.resource_group.name
@@ -107,9 +105,7 @@ resource "azurerm_monitor_metric_alert" "cpu" {
 }
 
 resource "azurerm_monitor_metric_alert" "memory" {
-  for_each = local.enable_monitoring ? (
-    length(local.monitor_container_ids) > 1 ? local.monitor_container_ids : toset(local.monitor_default_container_id)
-  ) : []
+  for_each = local.enable_monitoring ? local.monitor_container_ids : {}
 
   name                = "${element(split("/", each.value), length(split("/", each.value)) - 1)}-memory"
   resource_group_name = local.resource_group.name
@@ -160,7 +156,7 @@ resource "azurerm_monitor_metric_alert" "http" {
 }
 
 resource "azurerm_monitor_metric_alert" "count" {
-  for_each = local.enable_monitoring ? local.monitor_container_ids : []
+  for_each = local.enable_monitoring ? local.monitor_container_ids : {}
 
   name                = "${element(split("/", each.value), length(split("/", each.value)) - 1)}-replicas"
   resource_group_name = local.resource_group.name


### PR DESCRIPTION
> The "for_each" set includes values derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource.

> When working with unknown values in for_each, it's better to use a map value where the keys are defined statically in your configuration and

* This changes the `monitor_container_ids` from a set to a map, so that it can be ran for the first time