### PR TITLE
Fix network security group ids list

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -108,11 +108,9 @@ locals {
   network_watcher_flow_log_retention                                          = var.network_watcher_flow_log_retention
   enable_network_watcher_traffic_analytics                                    = var.enable_network_watcher_traffic_analytics
   network_watcher_traffic_analytics_interval                                  = var.network_watcher_traffic_analytics_interval
-  network_security_group_container_apps_infra_allow_frontdoor_inbound_only_id = local.launch_in_vnet && local.restrict_container_apps_to_cdn_inbound_only && local.enable_cdn_frontdoor ? [azurerm_network_security_group.container_apps_infra_allow_frontdoor_inbound_only[0].id] : []
-  network_security_group_ids = toset(
-    concat(
-      local.network_security_group_container_apps_infra_allow_frontdoor_inbound_only_id,
-    )
+  network_security_group_container_apps_infra_allow_frontdoor_inbound_only_id = local.launch_in_vnet && local.restrict_container_apps_to_cdn_inbound_only && local.enable_cdn_frontdoor ? { "container_apps_infra_allow_frontdoor_inbound_only" = azurerm_network_security_group.container_apps_infra_allow_frontdoor_inbound_only[0].id } : {}
+  network_security_group_ids = merge(
+    local.network_security_group_container_apps_infra_allow_frontdoor_inbound_only_id,
   )
   tagging_command                   = "timeout 15m ${path.module}/script/apply-tags-to-container-app-env-mc-resource-group -n \"${azapi_resource.container_app_env.name}\" -r \"${local.resource_group.name}\" -t \"${replace(jsonencode(local.tags), "\"", "\\\"")}\""
   enable_container_app_blob_storage = var.enable_container_app_blob_storage

--- a/network-watcher.tf
+++ b/network-watcher.tf
@@ -35,7 +35,7 @@ resource "azurerm_log_analytics_workspace" "default_network_watcher_nsg_flow_log
 }
 
 resource "azurerm_network_watcher_flow_log" "default_network_watcher_nsg" {
-  for_each = local.network_watcher_name != "" ? local.network_security_group_ids : []
+  for_each = local.network_watcher_name != "" ? local.network_security_group_ids : {}
 
   network_watcher_name = local.network_watcher_name
   resource_group_name  = local.network_watcher_resource_group_name


### PR DESCRIPTION
> The "for_each" set includes values derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource.

> When working with unknown values in for_each, it's better to use a map value where the keys are defined statically in your configuration and where only the values contain apply-time results.

* This changes the `network_security_group_ids` from a set to a map, so that it can be ran for the first time