### PR TITLE
Added Diagnostic Setting for Logic Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ module "azure_container_apps_hosting" {
 | [azurerm_logic_app_trigger_http_request.webhook](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_trigger_http_request) | resource |
 | [azurerm_logic_app_workflow.webhook](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_workflow) | resource |
 | [azurerm_monitor_action_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
+| [azurerm_monitor_diagnostic_setting.webhook](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_metric_alert.count](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.cpu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.http](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |

--- a/logic-app.tf
+++ b/logic-app.tf
@@ -43,3 +43,37 @@ resource "azurerm_logic_app_action_http" "slack" {
     }
   )
 }
+
+resource "azurerm_monitor_diagnostic_setting" "webhook" {
+  count = local.enable_monitoring ? 1 : 0
+
+  depends_on = [
+    azurerm_logic_app_workflow.webhook[0]
+  ]
+
+  name               = "${local.resource_prefix}-webhook-diag"
+  target_resource_id = azurerm_logic_app_workflow.webhook[0].id
+
+  log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
+  log_analytics_destination_type = "Dedicated"
+
+  eventhub_name = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
+
+  enabled_log {
+    category = "WorkflowRuntime"
+
+    retention_policy {
+      enabled = true
+      days    = 7
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+
+    retention_policy {
+      enabled = true
+      days    = 7
+    }
+  }
+}


### PR DESCRIPTION
Microsoft Defender for Cloud security recommendation.

**Policy**: Diagnostic logs in Logic Apps should be enabled

**Description**: To ensure you can recreate activity trails for investigation purposes when a security incident occurs or your network is compromised, enable logging. If your diagnostic logs aren't being sent to a Log Analytics workspace, Azure Storage account, or Azure Event Hub, ensure you've configured diagnostic settings to send platform metrics and platform logs to the relevant destinations. Learn more in Create diagnostic settings to send platform logs and metrics to different destinations.

**Severity**: Low