### PR TITLE
Updated provider version for azurerm to 3.46.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ module "azure_container_apps_hosting" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.9 |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 1.1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.41.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.46.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 
 ## Providers

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.41.0"
+      version = ">= 3.46.0"
     }
     azapi = {
       source  = "Azure/azapi"


### PR DESCRIPTION
This was missed from the Dependabot PR earlier