### PR TITLE
Added custom Log Analytics query pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ jobs:
 | [azurerm_eventhub_consumer_group.logstash](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventhub_consumer_group) | resource |
 | [azurerm_eventhub_namespace.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventhub_namespace) | resource |
 | [azurerm_log_analytics_data_export_rule.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_data_export_rule) | resource |
+| [azurerm_log_analytics_query_pack.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack) | resource |
 | [azurerm_log_analytics_workspace.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_log_analytics_workspace.default_network_watcher_nsg_flow_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_logic_app_action_http.slack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_http) | resource |

--- a/logging.tf
+++ b/logging.tf
@@ -17,6 +17,13 @@ resource "azurerm_log_analytics_data_export_rule" "container_app" {
   enabled                 = true
 }
 
+resource "azurerm_log_analytics_query_pack" "container_app" {
+  name                = "${local.resource_prefix}containerapp"
+  resource_group_name = local.resource_group.name
+  location            = local.resource_group.location
+  tags                = local.tags
+}
+
 resource "azurerm_eventhub_namespace" "container_app" {
   count               = local.enable_event_hub ? 1 : 0
   name                = "${local.resource_prefix}eventhubnamespace"


### PR DESCRIPTION
Having a custom query pack allows engineers to store custom Log Analytics Queries in a centralised place within their Resource Group. 

This ensures the correct tagging policies are adhered to as well.