### PR TITLE
Set a custom HTTP Header for the HTTP check

### DIFF
--- a/monitor.tf
+++ b/monitor.tf
@@ -27,6 +27,11 @@ resource "azurerm_application_insights_standard_web_test" "main" {
 
   request {
     url = local.monitor_http_availability_url
+
+    header {
+      name  = "X-AppInsights-HttpTest"
+      value = azurerm_application_insights.main.name
+    }
   }
 
   tags = merge(


### PR DESCRIPTION
- Makes it easier to track requests to the health check endpoint that have originated from App Insights' HTTP Test