### PR TITLE
Fixes for network access rules

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -159,7 +159,10 @@ locals {
   )
   enable_container_app_blob_storage                = var.enable_container_app_blob_storage
   container_app_blob_storage_public_access_enabled = var.container_app_blob_storage_public_access_enabled
-  container_app_blob_storage_ipv4_allow_list       = var.container_app_blob_storage_ipv4_allow_list
+  container_app_blob_storage_ipv4_allow_list = concat(
+    jsondecode(azapi_resource.default.output).properties.outboundIpAddresses,
+    var.container_app_blob_storage_ipv4_allow_list
+  )
   container_app_blob_storage_sas_secret = local.enable_container_app_blob_storage ? [
     {
       name  = "connectionstrings--blobstorage",

--- a/mssql.tf
+++ b/mssql.tf
@@ -85,7 +85,7 @@ resource "azurerm_private_endpoint" "default_mssql" {
 }
 
 resource "azurerm_mssql_firewall_rule" "default_mssql" {
-  for_each = local.mssql_firewall_ipv4_allow_list
+  for_each = local.enable_mssql_database ? toset(local.mssql_firewall_ipv4_allow_list) : []
 
   name             = "${replace(local.resource_prefix, "-", "")}fw${each.key}"
   server_id        = azurerm_mssql_server.default[0].id

--- a/redis-cache.tf
+++ b/redis-cache.tf
@@ -52,7 +52,7 @@ resource "azurerm_redis_firewall_rule" "container_app_worker_static_ip" {
 }
 
 resource "azurerm_redis_firewall_rule" "default" {
-  for_each = local.redis_cache_firewall_ipv4_allow_list
+  for_each = local.enable_redis_cache ? toset(local.redis_cache_firewall_ipv4_allow_list) : []
 
   name                = "${replace(local.resource_prefix, "-", "")}fw${each.key}"
   redis_cache_name    = azurerm_redis_cache.default[0].name

--- a/storage.tf
+++ b/storage.tf
@@ -19,8 +19,8 @@ resource "azurerm_storage_account_network_rules" "container_app" {
   storage_account_id         = azurerm_storage_account.container_app[0].id
   default_action             = "Deny"
   bypass                     = ["AzureServices"]
-  virtual_network_subnet_ids = [local.virtual_network.id]
-  ip_rules                   = length(local.container_app_blob_storage_ipv4_allow_list) > 0 ? local.container_app_blob_storage_ipv4_allow_list : null
+  virtual_network_subnet_ids = [azurerm_subnet.container_apps_infra_subnet[0].id]
+  ip_rules                   = local.container_app_blob_storage_ipv4_allow_list
 
   private_link_access {
     endpoint_resource_id = azapi_resource.default.id

--- a/storage.tf
+++ b/storage.tf
@@ -19,8 +19,15 @@ resource "azurerm_storage_account_network_rules" "container_app" {
   storage_account_id         = azurerm_storage_account.container_app[0].id
   default_action             = "Deny"
   bypass                     = ["AzureServices"]
-  ip_rules                   = local.container_app_blob_storage_ipv4_allow_list
   virtual_network_subnet_ids = [local.virtual_network.id]
+
+  dynamic "ip_rules" {
+    for_each = length(local.container_app_blob_storage_ipv4_allow_list) > 0 ? [1] : []
+
+    content {
+      ip_rules = local.container_app_blob_storage_ipv4_allow_list
+    }
+  }
 
   private_link_access {
     endpoint_resource_id = azapi_resource.default.id

--- a/storage.tf
+++ b/storage.tf
@@ -20,14 +20,7 @@ resource "azurerm_storage_account_network_rules" "container_app" {
   default_action             = "Deny"
   bypass                     = ["AzureServices"]
   virtual_network_subnet_ids = [local.virtual_network.id]
-
-  dynamic "ip_rules" {
-    for_each = length(local.container_app_blob_storage_ipv4_allow_list) > 0 ? [1] : []
-
-    content {
-      ip_rules = local.container_app_blob_storage_ipv4_allow_list
-    }
-  }
+  ip_rules                   = length(local.container_app_blob_storage_ipv4_allow_list) > 0 ? local.container_app_blob_storage_ipv4_allow_list : null
 
   private_link_access {
     endpoint_resource_id = azapi_resource.default.id


### PR DESCRIPTION
This Pr fixes an `Invalid for_each argument` error with the IPv4 network rules for the MSSQL and Redis instances.

Additionally it now correctly includes the Container Apps subnet ID which was previously invalid.

Finally, it will now always include the Container App static IP address within the network ACL for the Blob Storage Account, in addition to the Private Link