### PR TITLE
Ability to set custom container app names

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ module "azure_container_apps_hosting" {
   ## Specify the name of an existing Resource Group to deploy resources into
   # existing_resource_group = "my-existing-resource-group"
 
+  ## Specify the name of the container app environment (up to 32 characters)
+  # container_app_env_name = "my-container-app-environment"
+
+  ## Specify the name of the container app web instance (up to 32 characters)
+  # container_app_name = "my-container-app-web"
+
+  ## Specify the name of the container app worker instance (up to 32 characters)
+  # container_app_worker_name = "my-container-app-worker"
+
   # Set the default IP Range that will be assigned to the Virtual Network used by the Container Apps
   virtual_network_address_space = "172.32.10.0/24"
 
@@ -556,6 +565,9 @@ jobs:
 | <a name="input_cdn_frontdoor_waf_mode"></a> [cdn\_frontdoor\_waf\_mode](#input\_cdn\_frontdoor\_waf\_mode) | CDN Front Door waf mode | `string` | `"Prevention"` | no |
 | <a name="input_container_app_blob_storage_ipv4_allow_list"></a> [container\_app\_blob\_storage\_ipv4\_allow\_list](#input\_container\_app\_blob\_storage\_ipv4\_allow\_list) | A list of public IPv4 address to grant access to the Blob Storage Account | `list(string)` | `[]` | no |
 | <a name="input_container_app_blob_storage_public_access_enabled"></a> [container\_app\_blob\_storage\_public\_access\_enabled](#input\_container\_app\_blob\_storage\_public\_access\_enabled) | Should the Azure Storage Account have Public visibility? | `bool` | `false` | no |
+| <a name="input_container_app_env_name"></a> [container\_app\_env\_name](#input\_container\_app\_env\_name) | A custom name for the container app environment | `string` | `""` | no |
+| <a name="input_container_app_name"></a> [container\_app\_name](#input\_container\_app\_name) | A custom name for the container app web instance | `string` | `""` | no |
+| <a name="input_container_app_worker_name"></a> [container\_app\_worker\_name](#input\_container\_app\_worker\_name) | A custom name for the container app worker instance | `string` | `""` | no |
 | <a name="input_container_command"></a> [container\_command](#input\_container\_command) | Container command | `list(any)` | `[]` | no |
 | <a name="input_container_cpu"></a> [container\_cpu](#input\_container\_cpu) | Number of container CPU cores | `number` | `1` | no |
 | <a name="input_container_environment_variables"></a> [container\_environment\_variables](#input\_container\_environment\_variables) | Container environment variables | `map(string)` | `{}` | no |

--- a/container-app.tf
+++ b/container-app.tf
@@ -2,7 +2,7 @@ resource "azapi_resource" "container_app_env" {
   type      = "Microsoft.App/managedEnvironments@2022-03-01"
   parent_id = local.resource_group.id
   location  = local.resource_group.location
-  name      = "${local.resource_prefix}containerapp"
+  name      = local.container_app_env_name
 
   body = jsonencode({
     properties = {
@@ -31,7 +31,7 @@ resource "azapi_resource" "default" {
   type      = "Microsoft.App/containerApps@2022-03-01"
   parent_id = local.resource_group.id
   location  = local.resource_group.location
-  name      = "${local.resource_prefix}-${local.image_name}"
+  name      = local.container_app_name
   body = jsonencode({
     properties : {
       managedEnvironmentId = azapi_resource.container_app_env.id
@@ -170,7 +170,7 @@ resource "azapi_resource" "worker" {
   type      = "Microsoft.App/containerApps@2022-03-01"
   parent_id = local.resource_group.id
   location  = local.resource_group.location
-  name      = "${local.resource_prefix}-${local.image_name}-worker"
+  name      = local.container_app_worker_name
   body = jsonencode({
     properties : {
       managedEnvironmentId = azapi_resource.container_app_env.id

--- a/locals.tf
+++ b/locals.tf
@@ -171,5 +171,8 @@ locals {
       value = "${azurerm_storage_account.container_app[0].primary_blob_endpoint}${azurerm_storage_container.container_app[0].name}${data.azurerm_storage_account_blob_container_sas.container_app[0].sas}"
     }
   ] : []
-  tagging_command = "timeout 15m ${path.module}/script/apply-tags-to-container-app-env-mc-resource-group -n \"${azapi_resource.container_app_env.name}\" -r \"${local.resource_group.name}\" -t \"${replace(jsonencode(local.tags), "\"", "\\\"")}\""
+  container_app_env_name    = var.container_app_env_name == "" ? "${local.resource_prefix}containerapp" : var.container_app_env_name
+  container_app_name        = var.container_app_name == "" ? "${local.resource_prefix}-${local.image_name}" : var.container_app_name
+  container_app_worker_name = var.container_app_worker_name == "" ? "${local.resource_prefix}-${local.image_name}-worker" : var.container_app_worker_name
+  tagging_command           = "timeout 15m ${path.module}/script/apply-tags-to-container-app-env-mc-resource-group -n \"${azapi_resource.container_app_env.name}\" -r \"${local.resource_group.name}\" -t \"${replace(jsonencode(local.tags), "\"", "\\\"")}\""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -675,3 +675,33 @@ variable "container_app_blob_storage_ipv4_allow_list" {
   type        = list(string)
   default     = []
 }
+
+variable "container_app_env_name" {
+  type        = string
+  description = "A custom name for the container app environment"
+  default     = ""
+  validation {
+    condition     = length(var.container_app_env_name) <= 32
+    error_message = "Must be 32 characters or less"
+  }
+}
+
+variable "container_app_name" {
+  type        = string
+  description = "A custom name for the container app web instance"
+  default     = ""
+  validation {
+    condition     = length(var.container_app_name) <= 32
+    error_message = "Must be 32 characters or less"
+  }
+}
+
+variable "container_app_worker_name" {
+  type        = string
+  description = "A custom name for the container app worker instance"
+  default     = ""
+  validation {
+    condition     = length(var.container_app_worker_name) <= 32
+    error_message = "Must be 32 characters or less"
+  }
+}


### PR DESCRIPTION
The default method of using prefix and image name was causing my application to fail to deploy container apps due to hitting the 32 character limit.

Example docker image causing the issue:
```
dfe-digital/buy-for-your-school:a25128d
```

So I have implemented an optional variable to allow me to specify a short and descriptive name.

```
module "ghbs_application" {
  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=...

  # ...

  container_app_env_name      = "s174d01-ghbs-ca-env"
  container_app_name             = "s174d01-ghbs-ca-app"
  container_app_worker_name = "s174d01-ghbs-ca-worker"
}
```
