### PR TITLE
Ensure long docker image names still meet container app name limits

### DIFF
--- a/container-app.tf
+++ b/container-app.tf
@@ -31,7 +31,7 @@ resource "azapi_resource" "default" {
   type      = "Microsoft.App/containerApps@2022-03-01"
   parent_id = local.resource_group.id
   location  = local.resource_group.location
-  name      = "${local.resource_prefix}-${local.image_name}"
+  name      = substr("${local.resource_prefix}-${replace(element(split("/", local.image_name), length(split("/", local.image_name)) - 1), "-", "")}", 0, 32)
   body = jsonencode({
     properties : {
       managedEnvironmentId = azapi_resource.container_app_env.id
@@ -170,7 +170,7 @@ resource "azapi_resource" "worker" {
   type      = "Microsoft.App/containerApps@2022-03-01"
   parent_id = local.resource_group.id
   location  = local.resource_group.location
-  name      = "${local.resource_prefix}-${local.image_name}-worker"
+  name      = substr("${local.resource_prefix}-${replace(element(split("/", local.image_name), length(split("/", local.image_name)) - 1), "-", "")}-worker", 0, 32)
   body = jsonencode({
     properties : {
       managedEnvironmentId = azapi_resource.container_app_env.id


### PR DESCRIPTION
Problem 1: Our docker image name is too long and causes the 32 character limit on container app names to be hit
Problem 2: Our docker image name has slashes in it and breakes azure resource id format

Taking feedback received on https://github.com/DFE-Digital/terraform-azurerm-container-apps-hosting/pull/167 I have revised my solution to be more in keeping with your existing solution.

I do appreciate that is a confusing bit of string manipluation so I am open to feedback / suggestions.