### PR TITLE
Switch monitor aggregation to minimum

### DIFF
--- a/monitor.tf
+++ b/monitor.tf
@@ -227,7 +227,7 @@ resource "azurerm_monitor_metric_alert" "latency" {
   criteria {
     metric_namespace = "Microsoft.Cdn/profiles"
     metric_name      = "TotalLatency"
-    aggregation      = "Average"
+    aggregation      = "Minimum"
     operator         = "GreaterThan"
     # 1,000ms = 1s
     threshold = local.alarm_latency_threshold_ms


### PR DESCRIPTION
* This will help reduce noise in the alerts by basing the monitor check on the smallest value in the 5 minute range. With this change it will be easier to identify a consistently increased latency