### PR TITLE
Use correct Logic App trigger url in logic_app_receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ jobs:
 | [azurerm_subnet_route_table_association.redis_cache_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |
 | [azurerm_virtual_network.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [null_resource.tagging](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [azapi_resource_action.existing_logic_app_workflow_callback_url](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource_action) | data source |
 | [azurerm_logic_app_workflow.existing_logic_app_workflow](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/logic_app_workflow) | data source |
 | [azurerm_resource_group.existing_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_storage_account_blob_container_sas.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account_blob_container_sas) | data source |

--- a/data.tf
+++ b/data.tf
@@ -19,3 +19,20 @@ data "azurerm_logic_app_workflow" "existing_logic_app_workflow" {
   name                = local.existing_logic_app_workflow.name
   resource_group_name = local.existing_logic_app_workflow.resource_group_name
 }
+
+# There is not currently a way to get the full HTTP Trigger callback URL from a Logic App
+# so we have to use AzAPI to query the Logic App Workflow for the value instead.
+# https://github.com/hashicorp/terraform-provider-azurerm/issues/18866
+data "azapi_resource_action" "existing_logic_app_workflow_callback_url" {
+  count = local.existing_logic_app_workflow.name == "" ? 0 : 1
+
+  resource_id = "${data.azurerm_logic_app_workflow.existing_logic_app_workflow[0].id}/triggers/manual"
+  action      = "listCallbackUrl"
+  type        = "Microsoft.Logic/workflows/triggers@2018-07-01-preview"
+
+  depends_on = [
+    data.azurerm_logic_app_workflow.existing_logic_app_workflow[0]
+  ]
+
+  response_export_values = ["value"]
+}

--- a/locals.tf
+++ b/locals.tf
@@ -180,7 +180,7 @@ locals {
   existing_logic_app_workflow     = var.existing_logic_app_workflow
   logic_app_workflow_name         = local.existing_logic_app_workflow.name == "" ? (local.enable_monitoring ? azurerm_logic_app_workflow.webhook[0].name : "") : data.azurerm_logic_app_workflow.existing_logic_app_workflow[0].name
   logic_app_workflow_id           = local.existing_logic_app_workflow.name == "" ? (local.enable_monitoring ? azurerm_logic_app_workflow.webhook[0].id : "") : data.azurerm_logic_app_workflow.existing_logic_app_workflow[0].id
-  logic_app_workflow_callback_url = local.existing_logic_app_workflow.name == "" ? (local.enable_monitoring ? azurerm_logic_app_workflow.webhook[0].access_endpoint : "") : data.azurerm_logic_app_workflow.existing_logic_app_workflow[0].access_endpoint
+  logic_app_workflow_callback_url = local.existing_logic_app_workflow.name == "" ? (local.enable_monitoring ? azurerm_logic_app_trigger_http_request.webhook[0].callback_url : "") : jsondecode(data.azapi_resource_action.existing_logic_app_workflow_callback_url[0].output).value
   monitor_email_receivers         = var.monitor_email_receivers
   monitor_endpoint_healthcheck    = var.monitor_endpoint_healthcheck
   monitor_http_availability_fqdn = local.enable_cdn_frontdoor ? (


### PR DESCRIPTION
- In commit fca604ae5ca185de5819e6d1f2432f57d4f912cf a change to the logic_app_receiver block in the monitor action group changed the trigger url of the Logic App Workflow to be dynamic based on whether the operator is supplying their own Logic App workflow resource or choosing to create one with the module.
- If operators chose to create the Logic app workflow using the module, the actual value that was set was invalid and only contained the base url of the workflow. This meant that any requests to the workflow would fail silenty.
- The trigger url must contain an authenticated token which is only possible if using the callback_url attribute of the HTTP Trigger.
- The callback_url attribute cannot be gotten from a data source so the fix is to load it using a AzApi request instead.
