### PR TITLE
Add conditional check for exception metric

### DIFF
--- a/monitor.tf
+++ b/monitor.tf
@@ -137,6 +137,8 @@ resource "azurerm_monitor_metric_alert" "memory" {
 }
 
 resource "azurerm_monitor_metric_alert" "exceptions" {
+  count = local.enable_monitoring ? 1 : 0
+
   name                = "${azurerm_application_insights.main.name}-exceptions"
   resource_group_name = local.resource_group.name
   scopes              = [azurerm_application_insights.main.id]


### PR DESCRIPTION
**Issue:**
If `enable_monitoring` is set to `false` then the Action Group does not get deployed which means this metric alert cannot locate the resource reference.

**Fix:**
Add a conditional check that means the metric alert only gets created if monitoring is enabled