### PR TITLE
Add missing metric to diagnostic setting

### DIFF
--- a/network-watcher.tf
+++ b/network-watcher.tf
@@ -46,9 +46,21 @@ resource "azurerm_monitor_diagnostic_setting" "default_network_watcher_nsg_flow_
   log_analytics_destination_type = "Dedicated"
 
   metric {
-    category = "Transaction"
+    category = "Capacity"
+    enabled  = true
 
     retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "Transaction"
+    enabled  = true
+
+    retention_policy {
+      days    = 0
       enabled = false
     }
   }


### PR DESCRIPTION
- The 'Capacity' metric will show as a removal in Terraform plan if it is not included in the diagnostic setting resource