### PR TITLE
Add DNS Zone name servers as output

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,6 +795,7 @@ jobs:
 
 | Name | Description |
 |------|-------------|
+| <a name="output_azurerm_dns_zone_name_servers"></a> [azurerm\_dns\_zone\_name\_servers](#output\_azurerm\_dns\_zone\_name\_servers) | Name servers of the DNS Zone |
 | <a name="output_azurerm_eventhub_container_app"></a> [azurerm\_eventhub\_container\_app](#output\_azurerm\_eventhub\_container\_app) | Container App Event Hub |
 | <a name="output_azurerm_log_analytics_workspace_container_app"></a> [azurerm\_log\_analytics\_workspace\_container\_app](#output\_azurerm\_log\_analytics\_workspace\_container\_app) | Container App Log Analytics Workspace |
 | <a name="output_azurerm_resource_group_default"></a> [azurerm\_resource\_group\_default](#output\_azurerm\_resource\_group\_default) | Default Azure Resource Group |

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "azurerm_eventhub_container_app" {
   description = "Container App Event Hub"
 }
 
+output "azurerm_dns_zone_name_servers" {
+  value       = local.enable_dns_zone ? azurerm_dns_zone.default[0].name_servers : null
+  description = "Name servers of the DNS Zone"
+}
+
 output "cdn_frontdoor_dns_records" {
   value = local.cdn_frontdoor_custom_domains_create_dns_records == false ? concat([
     for domain in local.cdn_frontdoor_custom_domain_dns_names : {


### PR DESCRIPTION
To allow users to link the terraform created DNS zone with another DNS zone either manually or through terraform in another resource.