### PR TITLE
Fix location reference for geolocation lookup

### DIFF
--- a/container-app.tf
+++ b/container-app.tf
@@ -22,6 +22,7 @@ resource "azapi_resource" "container_app_env" {
 
   response_export_values = [
     "properties.staticIp",
+    "location"
   ]
 
   tags = local.tags

--- a/data.tf
+++ b/data.tf
@@ -38,5 +38,5 @@ data "azapi_resource_action" "existing_logic_app_workflow_callback_url" {
 }
 
 data "azurerm_extended_locations" "geo_locations" {
-  location = local.resource_group.location
+  location = jsondecode(azapi_resource.container_app_env.output).location
 }


### PR DESCRIPTION
`resource_group.location` == `westeurope` which is a region SKU and not a valid name that we can use in the `data` object which breaks any resource that implements the object.

Changing this to the `location` property of the Container App Environment output returns `West Europe` which is more appropriate.