### PR TITLE
Revert change to geo-location lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,6 @@ jobs:
 | [azurerm_virtual_network.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [null_resource.tagging](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [azapi_resource_action.existing_logic_app_workflow_callback_url](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource_action) | data source |
-| [azurerm_extended_locations.geo_locations](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/extended_locations) | data source |
 | [azurerm_logic_app_workflow.existing_logic_app_workflow](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/logic_app_workflow) | data source |
 | [azurerm_resource_group.existing_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_storage_account_blob_container_sas.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account_blob_container_sas) | data source |

--- a/container-app.tf
+++ b/container-app.tf
@@ -21,8 +21,7 @@ resource "azapi_resource" "container_app_env" {
   })
 
   response_export_values = [
-    "properties.staticIp",
-    "location"
+    "properties.staticIp"
   ]
 
   tags = local.tags

--- a/data.tf
+++ b/data.tf
@@ -36,7 +36,3 @@ data "azapi_resource_action" "existing_logic_app_workflow_callback_url" {
 
   response_export_values = ["value"]
 }
-
-data "azurerm_extended_locations" "geo_locations" {
-  location = jsondecode(azapi_resource.container_app_env.output).location
-}

--- a/monitor.tf
+++ b/monitor.tf
@@ -19,7 +19,11 @@ resource "azurerm_application_insights_standard_web_test" "main" {
   description             = "Regional HTTP availability check"
   enabled                 = true
 
-  geo_locations = slice(data.azurerm_extended_locations.geo_locations.extended_locations, 0, 3) # Use 3 locations
+  geo_locations = [
+    "emea-nl-ams-azr",  # West Europe
+    "emea-se-sto-edge", # UK West
+    "emea-ru-msa-edge"  # UK South
+  ]
 
   request {
     url = local.monitor_http_availability_url
@@ -49,7 +53,7 @@ resource "azurerm_application_insights_standard_web_test" "tls" {
   description             = "TLS certificate validity check"
   enabled                 = true
 
-  geo_locations = slice(data.azurerm_extended_locations.geo_locations.extended_locations, 0, 1) # Use 1 location
+  geo_locations = ["emea-nl-ams-azr"] # West Europe
 
   request {
     url                              = local.monitor_http_availability_url


### PR DESCRIPTION
- Using the azurerm_extended_locations was invalid and did not do what was anticipated
- This change reverts back to using hardcoded location tags

See:
https://learn.microsoft.com/en-gb/previous-versions/azure/azure-monitor/app/monitor-web-app-availability#azure