### PR TITLE
Add depends_on vnet link to postgres resource

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -57,9 +57,9 @@ locals {
   postgresql_network_connectivity_method = var.postgresql_network_connectivity_method
   postgresql_firewall_ipv4_allow = merge(
     {
-      "container-apps-env" = {
-        start_ip_address = jsondecode(azapi_resource.container_app_env.output).properties.staticIp
-        end_ip_address   = jsondecode(azapi_resource.container_app_env.output).properties.staticIp
+      "container-app" = {
+        start_ip_address = jsondecode(azapi_resource.default.output).properties.outboundIpAddresses[0]
+        end_ip_address   = jsondecode(azapi_resource.default.output).properties.outboundIpAddresses[0]
       }
     },
     var.postgresql_firewall_ipv4_allow

--- a/postgres.tf
+++ b/postgres.tf
@@ -13,6 +13,8 @@ resource "azurerm_postgresql_flexible_server" "default" {
   storage_mb             = local.postgresql_max_storage_mb
   sku_name               = local.postgresql_sku_name
   tags                   = local.tags
+
+  depends_on = [azurerm_private_dns_zone_virtual_network_link.postgresql_private_link[0]]
 }
 
 resource "azurerm_postgresql_flexible_server_database" "default" {


### PR DESCRIPTION
This is required when using postgres private networking.
Also, automatically add container app IP to postgres firewall - removed the container apps env line as that doesn't actually help the app connect.