### PR TITLE
Remove unnecessary data source reference for container app fqdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,7 +663,6 @@ jobs:
 | [azurerm_subnet_route_table_association.redis_cache_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |
 | [azurerm_virtual_network.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 | [azapi_resource_action.existing_logic_app_workflow_callback_url](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource_action) | data source |
-| [azurerm_container_app.custom_container_apps](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_app) | data source |
 | [azurerm_logic_app_workflow.existing_logic_app_workflow](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/logic_app_workflow) | data source |
 | [azurerm_resource_group.existing_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_storage_account_blob_container_sas.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account_blob_container_sas) | data source |

--- a/cdn.tf
+++ b/cdn.tf
@@ -60,8 +60,8 @@ resource "azurerm_cdn_frontdoor_origin" "custom_container_apps" {
   cdn_frontdoor_origin_group_id  = azurerm_cdn_frontdoor_origin_group.custom_container_apps[each.key].id
   enabled                        = true
   certificate_name_check_enabled = true
-  host_name                      = data.azurerm_container_app.custom_container_apps[each.key].ingress[0].fqdn
-  origin_host_header             = data.azurerm_container_app.custom_container_apps[each.key].ingress[0].fqdn
+  host_name                      = azurerm_container_app.custom_container_apps[each.key].ingress[0].fqdn
+  origin_host_header             = azurerm_container_app.custom_container_apps[each.key].ingress[0].fqdn
   http_port                      = local.cdn_frontdoor_origin_http_port
   https_port                     = local.cdn_frontdoor_origin_https_port
 

--- a/data.tf
+++ b/data.tf
@@ -20,15 +20,6 @@ data "azurerm_logic_app_workflow" "existing_logic_app_workflow" {
   resource_group_name = local.existing_logic_app_workflow.resource_group_name
 }
 
-data "azurerm_container_app" "custom_container_apps" {
-  for_each = local.custom_container_apps
-
-  name                = each.key
-  resource_group_name = local.resource_group.name
-
-  depends_on = [azurerm_container_app.custom_container_apps]
-}
-
 # There is not currently a way to get the full HTTP Trigger callback URL from a Logic App
 # so we have to use AzAPI to query the Logic App Workflow for the value instead.
 # https://github.com/hashicorp/terraform-provider-azurerm/issues/18866

--- a/locals.tf
+++ b/locals.tf
@@ -86,7 +86,7 @@ locals {
   container_command                      = var.container_command
   container_environment_variables        = var.container_environment_variables
   container_secret_environment_variables = var.container_secret_environment_variables
-  container_fqdn                         = azurerm_container_app.container_apps["main"].latest_revision_fqdn
+  container_fqdn                         = azurerm_container_app.container_apps["main"].ingress[0].fqdn
   # Container App / Container image
   image_name = var.image_name
   image_tag  = var.image_tag


### PR DESCRIPTION
- We can get the FQDN from the container app resource instead of querying for a data source