### PR TITLE
Remove diagnostic settings deprecation retention policy

### DIFF
--- a/cdn.tf
+++ b/cdn.tf
@@ -359,10 +359,6 @@ resource "azurerm_monitor_diagnostic_setting" "cdn" {
 
     content {
       category = "FrontdoorWebApplicationFirewallLog"
-
-      retention_policy {
-        enabled = false
-      }
     }
   }
 
@@ -371,10 +367,6 @@ resource "azurerm_monitor_diagnostic_setting" "cdn" {
 
     content {
       category = "FrontdoorAccessLog"
-
-      retention_policy {
-        enabled = false
-      }
     }
   }
 
@@ -383,18 +375,10 @@ resource "azurerm_monitor_diagnostic_setting" "cdn" {
 
     content {
       category = "FrontdoorHealthProbeLog"
-
-      retention_policy {
-        enabled = false
-      }
     }
   }
 
   metric {
     category = "AllMetrics"
-
-    retention_policy {
-      enabled = false
-    }
   }
 }

--- a/logic-app.tf
+++ b/logic-app.tf
@@ -102,11 +102,6 @@ resource "azurerm_monitor_diagnostic_setting" "webhook" {
 
   enabled_log {
     category = "WorkflowRuntime"
-
-    retention_policy {
-      enabled = true
-      days    = 7
-    }
   }
 
   metric {

--- a/network-watcher.tf
+++ b/network-watcher.tf
@@ -48,21 +48,11 @@ resource "azurerm_monitor_diagnostic_setting" "default_network_watcher_nsg_flow_
   metric {
     category = "Capacity"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   metric {
     category = "Transaction"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 }
 

--- a/redis-cache.tf
+++ b/redis-cache.tf
@@ -112,11 +112,6 @@ resource "azurerm_monitor_diagnostic_setting" "default_redis_cache" {
 
   enabled_log {
     category = "ConnectedClientList"
-
-    retention_policy {
-      enabled = true
-      days    = 7
-    }
   }
 
   metric {

--- a/storage.tf
+++ b/storage.tf
@@ -47,10 +47,6 @@ resource "azurerm_monitor_diagnostic_setting" "container_app" {
 
   metric {
     category = "Transaction"
-
-    retention_policy {
-      enabled = false
-    }
   }
 }
 


### PR DESCRIPTION
`retention_policy` has been deprecated in favor of `azurerm_storage_management_policy` however, `retention_policy` is an optional value therefore, we can just remove it.