### PR TITLE
Allow optional overrides of the container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ module "azure_container_apps_hosting" {
   # registry_username = ""
   # registry_password = ""
 
+  ## Specify a custom name for the Container App
+  # container_app_name_override = "my-awesome-app"
+
   # Specify the Container Image and Tag that will get pulled from the Container Registry
   image_name = "my-app"
   image_tag  = "latest"
@@ -715,6 +718,7 @@ jobs:
 | <a name="input_container_app_environment_internal_load_balancer_enabled"></a> [container\_app\_environment\_internal\_load\_balancer\_enabled](#input\_container\_app\_environment\_internal\_load\_balancer\_enabled) | Should the Container Environment operate in Internal Load Balancing Mode? | `bool` | `false` | no |
 | <a name="input_container_app_file_share_mount_path"></a> [container\_app\_file\_share\_mount\_path](#input\_container\_app\_file\_share\_mount\_path) | A path inside your container where the File Share will be mounted to | `string` | `"/srv/app/storage"` | no |
 | <a name="input_container_app_identities"></a> [container\_app\_identities](#input\_container\_app\_identities) | Identities to assign to container app | <pre>object({<br>    type : string<br>    identity_ids : list(string)<br>  })</pre> | `null` | no |
+| <a name="input_container_app_name_override"></a> [container\_app\_name\_override](#input\_container\_app\_name\_override) | A custom name for the Container App | `string` | `""` | no |
 | <a name="input_container_apps_allow_ips_inbound"></a> [container\_apps\_allow\_ips\_inbound](#input\_container\_apps\_allow\_ips\_inbound) | Restricts access to the Container Apps by creating a network security group rule that only allow inbound traffic from the provided list of IPs | `list(string)` | `[]` | no |
 | <a name="input_container_apps_infra_subnet_service_endpoints"></a> [container\_apps\_infra\_subnet\_service\_endpoints](#input\_container\_apps\_infra\_subnet\_service\_endpoints) | Endpoints to assign to infra subnet | `list(string)` | `[]` | no |
 | <a name="input_container_command"></a> [container\_command](#input\_container\_command) | Container command | `list(any)` | `[]` | no |
@@ -805,7 +809,7 @@ jobs:
 | <a name="input_redis_cache_patch_schedule_hour"></a> [redis\_cache\_patch\_schedule\_hour](#input\_redis\_cache\_patch\_schedule\_hour) | Redis Cache patch schedule hour | `number` | `18` | no |
 | <a name="input_redis_cache_sku"></a> [redis\_cache\_sku](#input\_redis\_cache\_sku) | Redis Cache SKU | `string` | `"Basic"` | no |
 | <a name="input_redis_cache_version"></a> [redis\_cache\_version](#input\_redis\_cache\_version) | Redis Cache version | `number` | `6` | no |
-| <a name="input_registry_custom_image_url"></a> [registry\_custom\_image\_url](#input\_registry\_custom\_image\_url) | Custom image registry url (required if `use_external_container_registry_url` is true) | `string` | `""` | no |
+| <a name="input_registry_custom_image_url"></a> [registry\_custom\_image\_url](#input\_registry\_custom\_image\_url) | Custom image registry url (required if `use_external_container_registry` is true) | `string` | `""` | no |
 | <a name="input_registry_password"></a> [registry\_password](#input\_registry\_password) | Container registry password (required if `enable_container_registry` is false) | `string` | `""` | no |
 | <a name="input_registry_server"></a> [registry\_server](#input\_registry\_server) | Container registry server (required if `enable_container_registry` is false) | `string` | `""` | no |
 | <a name="input_registry_username"></a> [registry\_username](#input\_registry\_username) | Container registry username (required if `enable_container_registry` is false) | `string` | `""` | no |
@@ -814,7 +818,7 @@ jobs:
 | <a name="input_storage_account_ipv4_allow_list"></a> [storage\_account\_ipv4\_allow\_list](#input\_storage\_account\_ipv4\_allow\_list) | A list of public IPv4 address to grant access to the Storage Account | `list(string)` | `[]` | no |
 | <a name="input_storage_account_public_access_enabled"></a> [storage\_account\_public\_access\_enabled](#input\_storage\_account\_public\_access\_enabled) | Should the Azure Storage Account have Public visibility? | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | `{}` | no |
-| <a name="input_use_external_container_registry_url"></a> [use\_external\_container\_registry\_url](#input\_use\_external\_container\_registry\_url) | To use an existing container registry url set to true. The `registry_custom_image_url` must be set. | `bool` | `false` | yes |
+| <a name="input_use_external_container_registry_url"></a> [use\_external\_container\_registry\_url](#input\_use\_external\_container\_registry\_url) | Set to true to use an existing container registry url. The `registry_custom_url` must be set. | `bool` | `false` | no |
 | <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space) | Virtual Network address space CIDR | `string` | `"172.16.0.0/12"` | no |
 | <a name="input_worker_container_command"></a> [worker\_container\_command](#input\_worker\_container\_command) | Container command for the Worker container. `enable_worker_container` must be set to true for this to have any effect. | `list(string)` | `[]` | no |
 | <a name="input_worker_container_max_replicas"></a> [worker\_container\_max\_replicas](#input\_worker\_container\_max\_replicas) | Worker ontainer max replicas | `number` | `2` | no |

--- a/container-app.tf
+++ b/container-app.tf
@@ -26,7 +26,7 @@ resource "azurerm_container_app" "container_apps" {
     local.enable_worker_container ? ["worker"] : [],
   ))
 
-  name                         = each.value == "worker" ? "${local.resource_prefix}-${local.image_name}-worker" : "${local.resource_prefix}-${local.image_name}"
+  name                         = each.value == "worker" ? "${local.container_app_name}-worker" : local.container_app_name
   container_app_environment_id = azurerm_container_app_environment.container_app_env.id
   resource_group_name          = local.resource_group.name
   revision_mode                = "Single"

--- a/locals.tf
+++ b/locals.tf
@@ -90,6 +90,8 @@ locals {
   container_secret_environment_variables = var.container_secret_environment_variables
   container_fqdn                         = azurerm_container_app.container_apps["main"].ingress[0].fqdn
   container_app_identities               = var.container_app_identities
+  container_app_name_override            = var.container_app_name_override
+  container_app_name                     = local.container_app_name_override == "" ? "${local.resource_prefix}-${local.image_name}" : local.container_app_name_override
   # Container App / Container image
   image_name = var.image_name
   image_tag  = var.image_tag

--- a/variables.tf
+++ b/variables.tf
@@ -319,6 +319,12 @@ variable "container_port" {
   default     = 80
 }
 
+variable "container_app_name_override" {
+  type        = string
+  description = "A custom name for the Container App"
+  default     = ""
+}
+
 variable "enable_container_health_probe" {
   description = "Enable liveness probes for the Container"
   type        = bool


### PR DESCRIPTION
Being able to supply a custom container app name is useful when the `image_name` is too long or references an external container registry. e.g. _ghcr.io/_`DFE-Digital/foo` this would make the container name be `<prefix>-DFE-Digital/foo-app` which doesn't follow naming conventions