### PR TITLE
Enable overrides of default Redis configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,7 @@ jobs:
 | <a name="input_redis_cache_patch_schedule_hour"></a> [redis\_cache\_patch\_schedule\_hour](#input\_redis\_cache\_patch\_schedule\_hour) | Redis Cache patch schedule hour | `number` | `18` | no |
 | <a name="input_redis_cache_sku"></a> [redis\_cache\_sku](#input\_redis\_cache\_sku) | Redis Cache SKU | `string` | `"Basic"` | no |
 | <a name="input_redis_cache_version"></a> [redis\_cache\_version](#input\_redis\_cache\_version) | Redis Cache version | `number` | `6` | no |
+| <a name="input_redis_config"></a> [redis\_config](#input\_redis\_config) | Overrides for Redis Cache Configuration options | <pre>object({<br>    maxmemory_reserved : optional(number),<br>    maxmemory_delta : optional(number),<br>    maxfragmentationmemory_reserved : optional(number),<br>    maxmemory_policy : optional(string),<br>  })</pre> | `{}` | no |
 | <a name="input_registry_custom_image_url"></a> [registry\_custom\_image\_url](#input\_registry\_custom\_image\_url) | Custom image registry url (required if `use_external_container_registry` is true) | `string` | `""` | no |
 | <a name="input_registry_password"></a> [registry\_password](#input\_registry\_password) | Container registry password (required if `enable_container_registry` is false) | `string` | `""` | no |
 | <a name="input_registry_server"></a> [registry\_server](#input\_registry\_server) | Container registry server (required if `enable_container_registry` is false) | `string` | `""` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -78,6 +78,14 @@ locals {
   redis_cache_patch_schedule_day       = var.redis_cache_patch_schedule_day
   redis_cache_patch_schedule_hour      = var.redis_cache_patch_schedule_hour
   redis_cache_firewall_ipv4_allow_list = var.redis_cache_firewall_ipv4_allow_list
+  # Azure Cache for Redis/Configuration
+  redis_config_defaults = {
+    maxmemory_reserved              = local.redis_cache_sku == "Basic" ? 2 : local.redis_cache_sku == "Standard" ? 50 : local.redis_cache_sku == "Premium" ? 200 : null
+    maxmemory_delta                 = local.redis_cache_sku == "Basic" ? 2 : local.redis_cache_sku == "Standard" ? 50 : local.redis_cache_sku == "Premium" ? 200 : null
+    maxfragmentationmemory_reserved = local.redis_cache_sku == "Basic" ? 2 : local.redis_cache_sku == "Standard" ? 50 : local.redis_cache_sku == "Premium" ? 200 : null
+    maxmemory_policy                = "volatile-lru"
+  }
+  redis_config = merge(local.redis_config_defaults, var.redis_config)
 
   # Container App
   container_cpu                          = var.container_cpu

--- a/redis-cache.tf
+++ b/redis-cache.tf
@@ -18,7 +18,11 @@ resource "azurerm_redis_cache" "default" {
   ) : null
 
   redis_configuration {
-    enable_authentication = true
+    enable_authentication           = true
+    maxmemory_reserved              = local.redis_config.maxmemory_reserved
+    maxmemory_delta                 = local.redis_config.maxmemory_delta
+    maxmemory_policy                = local.redis_config.maxfragmentationmemory_reserved
+    maxfragmentationmemory_reserved = local.redis_config.maxmemory_policy
   }
 
   patch_schedule {

--- a/variables.tf
+++ b/variables.tf
@@ -278,6 +278,17 @@ variable "redis_cache_firewall_ipv4_allow_list" {
   default     = []
 }
 
+variable "redis_config" {
+  description = "Overrides for Redis Cache Configuration options"
+  type = object({
+    maxmemory_reserved : optional(number),
+    maxmemory_delta : optional(number),
+    maxfragmentationmemory_reserved : optional(number),
+    maxmemory_policy : optional(string),
+  })
+  default = {}
+}
+
 variable "image_name" {
   description = "Image name"
   type        = string


### PR DESCRIPTION
This change allows users to override the default configuration options for Redis.

I have set the default vars to match what [Azure defines](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache#default-redis-configuration-values)

- [maxmemory_reserved](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache#maxmemory_reserved) - (Optional) Value in megabytes reserved for non-cache usage e.g. failover.

- [maxmemory_delta](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache#maxmemory_delta) - (Optional) The max-memory delta for this Redis instance.

- [maxmemory_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache#maxmemory_policy) - (Optional) How Redis will select what to remove when maxmemory is reached. 

- [maxfragmentationmemory_reserved](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache#maxfragmentationmemory_reserved) - (Optional) Value in megabytes reserved to accommodate for memory fragmentation. 