### PR TITLE
Deploy a sidecar container

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,7 +649,6 @@ jobs:
 | [azurerm_private_endpoint.default_redis_cache](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_redis_cache.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache) | resource |
 | [azurerm_redis_firewall_rule.container_app_default_static_ip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_firewall_rule) | resource |
-| [azurerm_redis_firewall_rule.container_app_worker_static_ip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_firewall_rule) | resource |
 | [azurerm_redis_firewall_rule.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_firewall_rule) | resource |
 | [azurerm_resource_group.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_route_table.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route_table) | resource |
@@ -825,8 +824,6 @@ jobs:
 | <a name="input_use_external_container_registry_url"></a> [use\_external\_container\_registry\_url](#input\_use\_external\_container\_registry\_url) | Set to true to use an existing container registry url. The `registry_custom_url` must be set. | `bool` | `false` | no |
 | <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space) | Virtual Network address space CIDR | `string` | `"172.16.0.0/12"` | no |
 | <a name="input_worker_container_command"></a> [worker\_container\_command](#input\_worker\_container\_command) | Container command for the Worker container. `enable_worker_container` must be set to true for this to have any effect. | `list(string)` | `[]` | no |
-| <a name="input_worker_container_max_replicas"></a> [worker\_container\_max\_replicas](#input\_worker\_container\_max\_replicas) | Worker ontainer max replicas | `number` | `2` | no |
-| <a name="input_worker_container_min_replicas"></a> [worker\_container\_min\_replicas](#input\_worker\_container\_min\_replicas) | Worker container min replicas | `number` | `1` | no |
 
 ## Outputs
 

--- a/locals.tf
+++ b/locals.tf
@@ -65,8 +65,8 @@ locals {
   postgresql_firewall_ipv4_allow = merge(
     {
       "container-app" = {
-        start_ip_address = azurerm_container_app.container_apps["main"].outbound_ip_addresses[0]
-        end_ip_address   = azurerm_container_app.container_apps["main"].outbound_ip_addresses[0]
+        start_ip_address = azurerm_container_app.container_apps.outbound_ip_addresses[0]
+        end_ip_address   = azurerm_container_app.container_apps.outbound_ip_addresses[0]
       }
     },
     var.postgresql_firewall_ipv4_allow
@@ -99,7 +99,7 @@ locals {
   container_command                      = var.container_command
   container_environment_variables        = var.container_environment_variables
   container_secret_environment_variables = var.container_secret_environment_variables
-  container_fqdn                         = azurerm_container_app.container_apps["main"].ingress[0].fqdn
+  container_fqdn                         = azurerm_container_app.container_apps.ingress[0].fqdn
   container_app_identities               = var.container_app_identities
   container_app_name_override            = var.container_app_name_override
   container_app_name                     = local.container_app_name_override == "" ? "${local.resource_prefix}-${local.image_name}" : local.container_app_name_override
@@ -135,10 +135,8 @@ locals {
   }
   container_health_probe = lookup(local.container_health_probes, local.container_health_probe_protocol, null)
   # Container App / Sidecar
-  enable_worker_container       = var.enable_worker_container
-  worker_container_command      = var.worker_container_command
-  worker_container_min_replicas = var.worker_container_min_replicas
-  worker_container_max_replicas = var.worker_container_max_replicas
+  enable_worker_container  = var.enable_worker_container
+  worker_container_command = var.worker_container_command
   # Container app / Custom
   custom_container_apps = var.custom_container_apps
   custom_container_apps_cdn_frontdoor_custom_domain_dns_names = local.enable_cdn_frontdoor ? {
@@ -237,13 +235,8 @@ locals {
   monitor_http_availability_fqdn = local.enable_cdn_frontdoor ? (
     length(local.cdn_frontdoor_custom_domains) >= 1 ? local.cdn_frontdoor_custom_domains[0] : azurerm_cdn_frontdoor_endpoint.endpoint[0].host_name
   ) : local.container_fqdn
-  monitor_http_availability_url = "https://${local.monitor_http_availability_fqdn}${local.monitor_endpoint_healthcheck}"
-  monitor_default_container_id  = { "default_id" = azurerm_container_app.container_apps["main"].id }
-  monitor_worker_container_id   = local.enable_worker_container ? { "worker_id" = azurerm_container_app.container_apps["worker"].id } : {}
-  monitor_container_ids = merge(
-    local.monitor_default_container_id,
-    local.monitor_worker_container_id,
-  )
+  monitor_http_availability_url  = "https://${local.monitor_http_availability_fqdn}${local.monitor_endpoint_healthcheck}"
+  monitor_container_ids          = { "default_id" = azurerm_container_app.container_apps.id }
   monitor_enable_slack_webhook   = var.monitor_enable_slack_webhook
   monitor_slack_webhook_receiver = var.monitor_slack_webhook_receiver
   monitor_slack_channel          = var.monitor_slack_channel

--- a/redis-cache.tf
+++ b/redis-cache.tf
@@ -39,20 +39,8 @@ resource "azurerm_redis_firewall_rule" "container_app_default_static_ip" {
   name                = "${replace(local.resource_prefix, "-", "")}containerapp"
   redis_cache_name    = azurerm_redis_cache.default[0].name
   resource_group_name = local.resource_group.name
-  start_ip            = azurerm_container_app.container_apps["main"].outbound_ip_addresses[0]
-  end_ip              = azurerm_container_app.container_apps["main"].outbound_ip_addresses[0]
-}
-
-resource "azurerm_redis_firewall_rule" "container_app_worker_static_ip" {
-  count = local.enable_redis_cache ? (
-    local.enable_worker_container ? 1 : 0
-  ) : 0
-
-  name                = "${replace(local.resource_prefix, "-", "")}containerappworker"
-  redis_cache_name    = azurerm_redis_cache.default[0].name
-  resource_group_name = local.resource_group.name
-  start_ip            = azurerm_container_app.container_apps["worker"].outbound_ip_addresses[0]
-  end_ip              = azurerm_container_app.container_apps["worker"].outbound_ip_addresses[0]
+  start_ip            = azurerm_container_app.container_apps.outbound_ip_addresses[0]
+  end_ip              = azurerm_container_app.container_apps.outbound_ip_addresses[0]
 }
 
 resource "azurerm_redis_firewall_rule" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -409,18 +409,6 @@ variable "worker_container_command" {
   default     = []
 }
 
-variable "worker_container_min_replicas" {
-  description = "Worker container min replicas"
-  type        = number
-  default     = 1
-}
-
-variable "worker_container_max_replicas" {
-  description = "Worker ontainer max replicas"
-  type        = number
-  default     = 2
-}
-
 variable "enable_dns_zone" {
   description = "Conditionally create a DNS zone"
   type        = bool


### PR DESCRIPTION
- Previously we have been deploying an optional worker container as a separate container app but according to azure, a sidecar container should be launched under the same resource but as a 2nd container, instead of a separate container app.
- Users that intend on deploying a separate container app, can use the `custom_container_apps` variable

Source: https://learn.microsoft.com/en-us/azure/container-apps/containers#sidecar-containers