### PR TITLE
Removed deprecated diagnostic retention

### DIFF
--- a/logic-app.tf
+++ b/logic-app.tf
@@ -106,10 +106,5 @@ resource "azurerm_monitor_diagnostic_setting" "webhook" {
 
   metric {
     category = "AllMetrics"
-
-    retention_policy {
-      enabled = true
-      days    = 7
-    }
   }
 }

--- a/redis-cache.tf
+++ b/redis-cache.tf
@@ -116,10 +116,5 @@ resource "azurerm_monitor_diagnostic_setting" "default_redis_cache" {
 
   metric {
     category = "AllMetrics"
-
-    retention_policy {
-      enabled = true
-      days    = 7
-    }
   }
 }


### PR DESCRIPTION
Diagnostic retention settings are specified at the storage account management policy level instead now