### PR TITLE
Add Diagnostic Setting for Event Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ module "azure_container_apps_hosting" {
 | [azurerm_monitor_diagnostic_setting.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.default_network_watcher_nsg_flow_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.default_redis_cache](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
+| [azurerm_monitor_diagnostic_setting.event_hub](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.webhook](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_metric_alert.count](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.cpu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |

--- a/logging.tf
+++ b/logging.tf
@@ -34,6 +34,26 @@ resource "azurerm_eventhub_namespace" "container_app" {
   tags                = local.tags
 }
 
+resource "azurerm_monitor_diagnostic_setting" "event_hub" {
+  count = local.enable_monitoring && local.enable_event_hub ? 1 : 0
+
+  name               = "${local.resource_prefix}-eventhub-diag"
+  target_resource_id = azurerm_eventhub_namespace.container_app[0].id
+
+  log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
+  log_analytics_destination_type = "Dedicated"
+
+  eventhub_name = azurerm_eventhub.container_app[0].name
+
+  enabled_log {
+    category_group = "AllLogs"
+  }
+
+  metric {
+    category = "AllMetrics"
+  }
+}
+
 resource "azurerm_eventhub" "container_app" {
   count               = local.enable_event_hub ? 1 : 0
   name                = "${local.resource_prefix}containerapp"


### PR DESCRIPTION
## Microsoft Defender for Cloud recommendation:

**Diagnostic logs in Event Hub should be enabled**
This enables you to recreate activity trails for investigation purposes when a security incident occurs or your network is compromised.

**Severity**
Low