### PR TITLE
Notify and log SQL vulnerability assessment reports

### DIFF
--- a/mssql.tf
+++ b/mssql.tf
@@ -100,6 +100,9 @@ resource "azurerm_mssql_server_security_alert_policy" "default" {
   state               = "Enabled"
   email_account_admins       = true
   email_addresses            = local.monitor_email_receivers
+  retention_days             = 90
+  storage_endpoint           = azurerm_storage_account.mssql_security_storage[0].primary_blob_endpoint
+  storage_account_access_key = azurerm_storage_account.mssql_security_storage[0].primary_access_key
 }
 
 resource "azurerm_mssql_server_vulnerability_assessment" "default" {

--- a/mssql.tf
+++ b/mssql.tf
@@ -95,9 +95,9 @@ resource "azurerm_mssql_firewall_rule" "default_mssql" {
 resource "azurerm_mssql_server_security_alert_policy" "default" {
   count = local.enable_mssql_database && local.enable_mssql_vulnerability_assessment ? 1 : 0
 
-  resource_group_name = local.resource_group.name
-  server_name         = azurerm_mssql_server.default[0].name
-  state               = "Enabled"
+  resource_group_name        = local.resource_group.name
+  server_name                = azurerm_mssql_server.default[0].name
+  state                      = "Enabled"
   email_account_admins       = true
   email_addresses            = local.monitor_email_receivers
   retention_days             = 90

--- a/mssql.tf
+++ b/mssql.tf
@@ -98,6 +98,8 @@ resource "azurerm_mssql_server_security_alert_policy" "default" {
   resource_group_name = local.resource_group.name
   server_name         = azurerm_mssql_server.default[0].name
   state               = "Enabled"
+  email_account_admins       = true
+  email_addresses            = local.monitor_email_receivers
 }
 
 resource "azurerm_mssql_server_vulnerability_assessment" "default" {
@@ -110,5 +112,6 @@ resource "azurerm_mssql_server_vulnerability_assessment" "default" {
   recurring_scans {
     enabled                   = true
     email_subscription_admins = true
+    emails                    = local.monitor_email_receivers
   }
 }


### PR DESCRIPTION
If we're enabling the Security Alert policy, then we ought to notify people when alerts happen. 

We're also creating a storage container to hold security logs so we ought to write security alerts to the same place for auditing reasons.