### PR TITLE
App insights isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@ module "azure_container_apps_hosting" {
 | [azurerm_eventhub_namespace.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventhub_namespace) | resource |
 | [azurerm_log_analytics_data_export_rule.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_data_export_rule) | resource |
 | [azurerm_log_analytics_query_pack.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_query_pack) | resource |
+| [azurerm_log_analytics_workspace.app_insights](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_log_analytics_workspace.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_log_analytics_workspace.default_network_watcher_nsg_flow_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_logic_app_action_custom.var_affected_resource](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
@@ -651,6 +652,7 @@ module "azure_container_apps_hosting" {
 | <a name="input_alarm_log_ingestion_gb_per_day"></a> [alarm\_log\_ingestion\_gb\_per\_day](#input\_alarm\_log\_ingestion\_gb\_per\_day) | Define an alarm threshold for Log Analytics ingestion rate in GB (per day) (Defaults to no limit) | `number` | `0` | no |
 | <a name="input_alarm_memory_threshold_percentage"></a> [alarm\_memory\_threshold\_percentage](#input\_alarm\_memory\_threshold\_percentage) | Specify a number (%) which should be set as a threshold for a memory usage monitoring alarm | `number` | `80` | no |
 | <a name="input_alarm_tls_expiry_days_remaining"></a> [alarm\_tls\_expiry\_days\_remaining](#input\_alarm\_tls\_expiry\_days\_remaining) | Number of days remaining of TLS validity before an alarm should be raised | `number` | `30` | no |
+| <a name="input_app_insights_retention_days"></a> [app\_insights\_retention\_days](#input\_app\_insights\_retention\_days) | Number of days to retain App Insights data for (Default: 2 years) | `number` | `730` | no |
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Azure location in which to launch resources. | `string` | n/a | yes |
 | <a name="input_cdn_frontdoor_custom_domains"></a> [cdn\_frontdoor\_custom\_domains](#input\_cdn\_frontdoor\_custom\_domains) | Azure CDN Front Door custom domains | `list(string)` | `[]` | no |
 | <a name="input_cdn_frontdoor_custom_domains_create_dns_records"></a> [cdn\_frontdoor\_custom\_domains\_create\_dns\_records](#input\_cdn\_frontdoor\_custom\_domains\_create\_dns\_records) | Should the TXT records and ALIAS/CNAME records be automatically created if the custom domains exist within the DNS Zone? | `bool` | `true` | no |
@@ -706,6 +708,7 @@ module "azure_container_apps_hosting" {
 | <a name="input_dns_txt_records"></a> [dns\_txt\_records](#input\_dns\_txt\_records) | DNS TXT records to add to the DNS Zone | <pre>map(<br>    object({<br>      ttl : optional(number, 300),<br>      records : list(string)<br>    })<br>  )</pre> | `{}` | no |
 | <a name="input_dns_zone_domain_name"></a> [dns\_zone\_domain\_name](#input\_dns\_zone\_domain\_name) | DNS zone domain name. If created, records will automatically be created to point to the CDN. | `string` | `""` | no |
 | <a name="input_dns_zone_soa_record"></a> [dns\_zone\_soa\_record](#input\_dns\_zone\_soa\_record) | DNS zone SOA record block (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_zone#soa_record) | `map(string)` | `{}` | no |
+| <a name="input_enable_app_insights_integration"></a> [enable\_app\_insights\_integration](#input\_enable\_app\_insights\_integration) | Deploy an App Insights instance and connect your Container Apps to it | `bool` | `true` | no |
 | <a name="input_enable_cdn_frontdoor"></a> [enable\_cdn\_frontdoor](#input\_enable\_cdn\_frontdoor) | Enable Azure CDN Front Door. This will use the Container Apps endpoint as the origin. | `bool` | `false` | no |
 | <a name="input_enable_cdn_frontdoor_health_probe"></a> [enable\_cdn\_frontdoor\_health\_probe](#input\_enable\_cdn\_frontdoor\_health\_probe) | Enable CDN Front Door health probe | `bool` | `true` | no |
 | <a name="input_enable_container_app_blob_storage"></a> [enable\_container\_app\_blob\_storage](#input\_enable\_container\_app\_blob\_storage) | Create an Azure Storage Account and Storage Container to be used for this app | `bool` | `false` | no |

--- a/app-insights.tf
+++ b/app-insights.tf
@@ -1,0 +1,90 @@
+resource "azurerm_application_insights" "main" {
+  count = local.enable_app_insights_integration ? 1 : 0
+
+  name                = "${local.resource_prefix}-insights"
+  location            = local.resource_group.location
+  resource_group_name = local.resource_group.name
+  application_type    = "web"
+  workspace_id        = azurerm_log_analytics_workspace.app_insights[0].id
+  retention_in_days   = local.app_insights_retention_days
+  tags                = local.tags
+}
+
+resource "azurerm_log_analytics_workspace" "app_insights" {
+  count = local.enable_app_insights_integration ? 1 : 0
+
+  name                = "${local.resource_prefix}-insights"
+  location            = local.resource_group.location
+  resource_group_name = local.resource_group.name
+  sku                 = "PerGB2018"
+  retention_in_days   = local.app_insights_retention_days
+  tags                = local.tags
+}
+
+resource "azurerm_application_insights_standard_web_test" "main" {
+  count = local.enable_app_insights_integration && local.enable_monitoring ? 1 : 0
+
+  name                    = "${local.resource_prefix}-http"
+  resource_group_name     = local.resource_group.name
+  location                = local.resource_group.location
+  application_insights_id = azurerm_application_insights.main[0].id
+  timeout                 = 10
+  description             = "Regional HTTP availability check"
+  enabled                 = true
+
+  geo_locations = [
+    "emea-nl-ams-azr",  # West Europe
+    "emea-se-sto-edge", # UK West
+    "emea-ru-msa-edge"  # UK South
+  ]
+
+  request {
+    url = local.monitor_http_availability_url
+
+    header {
+      name  = "X-AppInsights-HttpTest"
+      value = azurerm_application_insights.main[0].name
+    }
+  }
+
+  tags = merge(
+    local.tags,
+    { "hidden-link:${azurerm_application_insights.main[0].id}" = "Resource" },
+  )
+}
+
+resource "azurerm_application_insights_standard_web_test" "tls" {
+  count = local.enable_app_insights_integration && local.enable_monitoring && local.monitor_tls_expiry ? 1 : 0
+
+  name                    = "${local.resource_prefix}-tls"
+  resource_group_name     = local.resource_group.name
+  location                = local.resource_group.location
+  application_insights_id = azurerm_application_insights.main[0].id
+  timeout                 = 60
+  frequency               = 900 # Interval in seconds to test. (15 mins)
+  retry_enabled           = true
+  description             = "TLS certificate validity check"
+  enabled                 = true
+
+  geo_locations = ["emea-nl-ams-azr"] # West Europe
+
+  request {
+    url                              = local.monitor_http_availability_url
+    parse_dependent_requests_enabled = false
+
+    header {
+      name  = "X-AppInsights-TlsExpiryTest"
+      value = azurerm_application_insights.main.name
+    }
+  }
+
+  validation_rules {
+    ssl_cert_remaining_lifetime = local.alarm_tls_expiry_days_remaining
+    ssl_check_enabled           = true
+  }
+
+  tags = merge(
+    local.tags,
+    { "hidden-link:${azurerm_application_insights.main[0].id}" = "Resource" },
+  )
+}

--- a/app-insights.tf
+++ b/app-insights.tf
@@ -74,7 +74,7 @@ resource "azurerm_application_insights_standard_web_test" "tls" {
 
     header {
       name  = "X-AppInsights-TlsExpiryTest"
-      value = azurerm_application_insights.main.name
+      value = azurerm_application_insights.main[0].name
     }
   }
 

--- a/custom-container-apps.tf
+++ b/custom-container-apps.tf
@@ -20,16 +20,17 @@ resource "azurerm_container_app" "custom_container_apps" {
   }
 
   dynamic "secret" {
-    for_each = { for i, v in concat([
-      {
-        "name" : "applicationinsights--connectionstring",
-        "value" : azurerm_application_insights.main.connection_string
-      },
-      {
-        "name" : "applicationinsights--instrumentationkey",
-        "value" : azurerm_application_insights.main.instrumentation_key
-      },
-      ],
+    for_each = { for i, v in concat(
+      local.enable_app_insights_integration ? [
+        {
+          name  = "applicationinsights--connectionstring",
+          value = azurerm_application_insights.main[0].connection_string
+        },
+        {
+          name  = "applicationinsights--instrumentationkey",
+          value = azurerm_application_insights.main[0].instrumentation_key
+        }
+      ] : [],
       each.value.secrets
     ) : v.name => v }
 
@@ -65,7 +66,7 @@ resource "azurerm_container_app" "custom_container_apps" {
       }
       dynamic "env" {
         for_each = { for i, v in concat(
-          [
+          local.enable_app_insights_integration ? [
             {
               "name" : "ApplicationInsights__ConnectionString",
               "secretRef" : "applicationinsights--connectionstring"
@@ -74,7 +75,7 @@ resource "azurerm_container_app" "custom_container_apps" {
               "name" : "ApplicationInsights__InstrumentationKey",
               "secretRef" : "applicationinsights--instrumentationkey"
             }
-          ],
+          ] : [],
           each.value.env,
         ) : v.name => v }
 

--- a/locals.tf
+++ b/locals.tf
@@ -291,6 +291,10 @@ locals {
   enable_logstash_consumer                  = var.enable_logstash_consumer
   eventhub_export_log_analytics_table_names = var.eventhub_export_log_analytics_table_names
 
+  # Application Insights
+  enable_app_insights_integration = var.enable_app_insights_integration
+  app_insights_retention_days     = var.app_insights_retention_days
+
   # Azure Monitor
   enable_monitoring = var.enable_monitoring
   # Azure Monitor / Logic App Workflow

--- a/monitor.tf
+++ b/monitor.tf
@@ -97,7 +97,7 @@ resource "azurerm_monitor_metric_alert" "memory" {
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "exceptions" {
   count = local.enable_monitoring && local.enable_app_insights_integration ? 1 : 0
 
-  name                 = "${azurerm_application_insights.main.name}-exceptions"
+  name                 = "${azurerm_application_insights.main[0].name}-exceptions"
   resource_group_name  = local.resource_group.name
   location             = local.resource_group.location
   evaluation_frequency = "PT5M"

--- a/variables.tf
+++ b/variables.tf
@@ -790,6 +790,18 @@ variable "eventhub_export_log_analytics_table_names" {
   default     = []
 }
 
+variable "enable_app_insights_integration" {
+  description = "Deploy an App Insights instance and connect your Container Apps to it"
+  type        = bool
+  default     = true
+}
+
+variable "app_insights_retention_days" {
+  description = "Number of days to retain App Insights data for (Default: 2 years)"
+  type        = number
+  default     = 730
+}
+
 variable "enable_monitoring" {
   description = "Create an App Insights instance and notification group for the Container App"
   type        = bool


### PR DESCRIPTION
* I've extracted App Insights resources and associated monitors into it's own file
* You can now specify a custom retention period for App Insights specific data
* A new Log Analytics workspace is deployed, exclusively for App Insights, with the same retention period. The justification for this is so that we can segregate system logs such as diagnostic settings and container logs, away from report-centric data such as user requests and app telemetry
* App Insights has become an optionally deployable resource (defaults to deploying by default). This is to cater to teams that may already be leveraging an existing App Insights resource