### PR TITLE
Update Diagnostic settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,11 +560,12 @@ module "azure_container_apps_hosting" {
 | [azurerm_logic_app_workflow.webhook](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_workflow) | resource |
 | [azurerm_management_lock.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) | resource |
 | [azurerm_monitor_action_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
+| [azurerm_monitor_diagnostic_setting.blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.cdn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
-| [azurerm_monitor_diagnostic_setting.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
-| [azurerm_monitor_diagnostic_setting.default_network_watcher_nsg_flow_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.default_redis_cache](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.event_hub](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
+| [azurerm_monitor_diagnostic_setting.files](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
+| [azurerm_monitor_diagnostic_setting.mssql_security_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.webhook](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_metric_alert.count](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.cpu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |

--- a/cdn.tf
+++ b/cdn.tf
@@ -377,8 +377,4 @@ resource "azurerm_monitor_diagnostic_setting" "cdn" {
       category = "FrontdoorHealthProbeLog"
     }
   }
-
-  metric {
-    category = "AllMetrics"
-  }
 }

--- a/logging.tf
+++ b/logging.tf
@@ -35,14 +35,12 @@ resource "azurerm_eventhub_namespace" "container_app" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "event_hub" {
-  count = local.enable_monitoring && local.enable_event_hub ? 1 : 0
+  count = local.enable_event_hub ? 1 : 0
 
   name               = "${local.resource_prefix}-eventhub-diag"
   target_resource_id = azurerm_eventhub_namespace.container_app[0].id
-
   log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
   log_analytics_destination_type = "Dedicated"
-
   eventhub_name = azurerm_eventhub.container_app[0].name
 
   enabled_log {

--- a/logging.tf
+++ b/logging.tf
@@ -37,11 +37,11 @@ resource "azurerm_eventhub_namespace" "container_app" {
 resource "azurerm_monitor_diagnostic_setting" "event_hub" {
   count = local.enable_event_hub ? 1 : 0
 
-  name               = "${local.resource_prefix}-eventhub-diag"
-  target_resource_id = azurerm_eventhub_namespace.container_app[0].id
+  name                           = "${local.resource_prefix}-eventhub-diag"
+  target_resource_id             = azurerm_eventhub_namespace.container_app[0].id
   log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
   log_analytics_destination_type = "Dedicated"
-  eventhub_name = azurerm_eventhub.container_app[0].name
+  eventhub_name                  = azurerm_eventhub.container_app[0].name
 
   enabled_log {
     category_group = "Audit"

--- a/logging.tf
+++ b/logging.tf
@@ -46,11 +46,7 @@ resource "azurerm_monitor_diagnostic_setting" "event_hub" {
   eventhub_name = azurerm_eventhub.container_app[0].name
 
   enabled_log {
-    category_group = "AllLogs"
-  }
-
-  metric {
-    category = "AllMetrics"
+    category_group = "Audit"
   }
 }
 

--- a/logic-app.tf
+++ b/logic-app.tf
@@ -103,8 +103,4 @@ resource "azurerm_monitor_diagnostic_setting" "webhook" {
   enabled_log {
     category = "WorkflowRuntime"
   }
-
-  metric {
-    category = "AllMetrics"
-  }
 }

--- a/mssql.tf
+++ b/mssql.tf
@@ -34,6 +34,20 @@ resource "azurerm_storage_container" "mssql_security_storage" {
   storage_account_name = azurerm_storage_account.mssql_security_storage[0].name
 }
 
+resource "azurerm_monitor_diagnostic_setting" "mssql_security_storage" {
+  count = local.enable_mssql_database ? 1 : 0
+
+  name                           = "${local.resource_prefix}-mssql-blob-diag"
+  target_resource_id             = azurerm_storage_container.mssql_security_storage[0].id
+  log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
+  log_analytics_destination_type = "Dedicated"
+  eventhub_name                  = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
+
+  enabled_log {
+    category_group = "Audit"
+  }
+}
+
 resource "azurerm_mssql_server" "default" {
   count = local.enable_mssql_database ? 1 : 0
 

--- a/network-watcher.tf
+++ b/network-watcher.tf
@@ -37,26 +37,6 @@ resource "azurerm_log_analytics_workspace" "default_network_watcher_nsg_flow_log
   tags = local.tags
 }
 
-resource "azurerm_monitor_diagnostic_setting" "default_network_watcher_nsg_flow_logs" {
-  count = local.network_watcher_name != "" && local.enable_network_watcher_traffic_analytics ? 1 : 0
-
-  name               = "${local.resource_prefix}-nwnsgd-diag"
-  target_resource_id = azurerm_storage_account.default_network_watcher_nsg_flow_logs[0].id
-
-  log_analytics_workspace_id     = azurerm_log_analytics_workspace.default_network_watcher_nsg_flow_logs[0].id
-  log_analytics_destination_type = "Dedicated"
-
-  metric {
-    category = "Capacity"
-    enabled  = true
-  }
-
-  metric {
-    category = "Transaction"
-    enabled  = true
-  }
-}
-
 resource "azurerm_network_watcher_flow_log" "default_network_watcher_nsg" {
   for_each = local.network_watcher_name != "" ? local.network_security_group_ids : {}
 
@@ -92,7 +72,7 @@ resource "azurerm_storage_account_network_rules" "default_network_watcher_nsg_fl
 
   storage_account_id = azurerm_storage_account.default_network_watcher_nsg_flow_logs[0].id
   default_action     = "Deny"
-  bypass             = ["AzureServices", "Logging", "Metrics"]
+  bypass             = ["AzureServices"]
 
   dynamic "private_link_access" {
     for_each = azurerm_network_watcher_flow_log.default_network_watcher_nsg

--- a/redis-cache.tf
+++ b/redis-cache.tf
@@ -69,8 +69,4 @@ resource "azurerm_monitor_diagnostic_setting" "default_redis_cache" {
   enabled_log {
     category = "ConnectedClientList"
   }
-
-  metric {
-    category = "AllMetrics"
-  }
 }

--- a/storage.tf
+++ b/storage.tf
@@ -39,17 +39,31 @@ resource "azurerm_storage_share" "container_app" {
   quota                = local.storage_account_file_share_quota_gb
 }
 
-resource "azurerm_monitor_diagnostic_setting" "container_app" {
+resource "azurerm_monitor_diagnostic_setting" "blob" {
   count = local.enable_container_app_blob_storage ? 1 : 0
 
-  name                           = "${local.resource_prefix}-storage-diag"
-  target_resource_id             = azurerm_storage_account.container_app[0].id
+  name                           = "${local.resource_prefix}-storage-blob-diag"
+  target_resource_id             = azurerm_storage_container.container_app[0].id
   log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
   log_analytics_destination_type = "Dedicated"
   eventhub_name                  = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
 
-  metric {
-    category = "Transaction"
+  enabled_log {
+    category_group = "Audit"
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "files" {
+  count = local.enable_container_app_file_share ? 1 : 0
+
+  name                           = "${local.resource_prefix}-storage-files-diag"
+  target_resource_id             = azurerm_storage_share.container_app[0].id
+  log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
+  log_analytics_destination_type = "Dedicated"
+  eventhub_name                  = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
+
+  enabled_log {
+    category_group = "Audit"
   }
 }
 


### PR DESCRIPTION
- We don't need to record any 'metric' type diagnostic settings because they are only useful if we were running deeper reports. We already have the data available to use in Azure Monitor, so we're ingesting log data unnecessarily
- Instead of specifying the types of log category, we can use the category group 'audit' to get the minimum required diagnostic logs
- I've added diagnostic settings for file shares in the storage account, and the mssql security log storage account