### PR TITLE
Register diagnostic settings for subresources in Storage Accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@ module "azure_container_apps_hosting" {
 | [azurerm_logic_app_workflow.webhook](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_workflow) | resource |
 | [azurerm_management_lock.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) | resource |
 | [azurerm_monitor_action_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
+| [azurerm_monitor_diagnostic_setting.blobs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.cdn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.default_redis_cache](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.event_hub](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |

--- a/mssql.tf
+++ b/mssql.tf
@@ -38,7 +38,7 @@ resource "azurerm_monitor_diagnostic_setting" "mssql_security_storage" {
   count = local.enable_mssql_database ? 1 : 0
 
   name                           = "${local.resource_prefix}-mssql-blob-diag"
-  target_resource_id             = azurerm_storage_container.mssql_security_storage[0].id
+  target_resource_id             = "${azurerm_storage_account.mssql_security_storage[0].id}/blobServices/default"
   log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
   log_analytics_destination_type = "Dedicated"
   eventhub_name                  = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null

--- a/storage.tf
+++ b/storage.tf
@@ -39,11 +39,25 @@ resource "azurerm_storage_share" "container_app" {
   quota                = local.storage_account_file_share_quota_gb
 }
 
+resource "azurerm_monitor_diagnostic_setting" "blobs" {
+  count = local.enable_container_app_blob_storage ? 1 : 0
+
+  name                           = "${local.resource_prefix}-storage-blobs-diag"
+  target_resource_id             = "${azurerm_storage_account.container_app[0].id}/blobServices/default"
+  log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
+  log_analytics_destination_type = "Dedicated"
+  eventhub_name                  = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
+
+  enabled_log {
+    category_group = "Audit"
+  }
+}
+
 resource "azurerm_monitor_diagnostic_setting" "files" {
   count = local.enable_container_app_file_share ? 1 : 0
 
   name                           = "${local.resource_prefix}-storage-files-diag"
-  target_resource_id             = azurerm_storage_share.container_app[0].id
+  target_resource_id             = "${azurerm_storage_account.container_app[0].id}/fileServices/default"
   log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
   log_analytics_destination_type = "Dedicated"
   eventhub_name                  = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null


### PR DESCRIPTION
As referenced in https://github.com/hashicorp/terraform-provider-azurerm/issues/22859, it's not possible to attach a Diagnostic Setting resource directly to a Storage Container, so instead we have to use the parent Storage Account resource ID, and then reference the subresource as appropriate (either 'blobServices', 'fileServices', 'queueServices', or 'tableServices')

Source: https://github.com/hashicorp/terraform-provider-azurerm/issues/8275#issuecomment-755222989