### PR TITLE
Set ACR password to abitrary string when admin credentials are disabled

### DIFF
--- a/container-app.tf
+++ b/container-app.tf
@@ -49,7 +49,7 @@ resource "azurerm_container_app" "container_apps" {
       [
         {
           "name" : "acr-password",
-          "value" : local.registry_password
+          "value" : local.registry_use_managed_identity && !local.registry_admin_enabled ? "not-in-use" : local.registry_password
         }
       ],
       local.enable_app_insights_integration ? [


### PR DESCRIPTION
* It is currently not possible to remove secrets from Container App definitions, and we can't set the value to null, so we should just set it to an abitrary string so it doesnt error (https://github.com/hashicorp/terraform-provider-azurerm/issues/21739)

* This is only necessary when the 'admin' credentials are disabled for the registry and I have included a check for using the managed identity to be sure the value will not be used