### PR TITLE
Fix invalid iteration reference

### DIFF
--- a/custom-container-apps.tf
+++ b/custom-container-apps.tf
@@ -41,7 +41,7 @@ resource "azurerm_container_app" "custom_container_apps" {
   }
 
   dynamic "identity" {
-    for_each = length(each.value.identity) > 0 ? [1] : []
+    for_each = each.value.identity
 
     content {
       type         = identity.value.type


### PR DESCRIPTION
Using `length(each.value.identity) > 0 ? [1] : []` for the `for_each` was invalid because in the dynamic block I was referencing the value as if it was an object, but it was just the number `1` 🙃 