### PR TITLE
Set diagnostic settings for Container App environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ module "azure_container_apps_hosting" {
 | [azurerm_monitor_action_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
 | [azurerm_monitor_diagnostic_setting.blobs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.cdn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
+| [azurerm_monitor_diagnostic_setting.container_app_env](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.default_redis_cache](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.event_hub](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.files](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |

--- a/container-app.tf
+++ b/container-app.tf
@@ -9,6 +9,17 @@ resource "azurerm_container_app_environment" "container_app_env" {
   tags = local.tags
 }
 
+resource "azurerm_monitor_diagnostic_setting" "container_app_env" {
+  name                       = "${local.resource_prefix}-containerapp-diag"
+  target_resource_id         = azurerm_container_app_environment.container_app_env.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.container_app.id
+  eventhub_name              = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
+
+  enabled_log {
+    category_group = "Audit"
+  }
+}
+
 resource "azurerm_container_app_environment_storage" "container_app_env" {
   count = local.enable_container_app_file_share ? 1 : 0
 


### PR DESCRIPTION
If the Log setting for the Container App environment is switched from Log Analytics to Azure Monitor, then we ought to ensure there is a destination configured for the logs by default.