### PR TITLE
Fix [tflint] deprecated Lookup

### DIFF
--- a/container-app.tf
+++ b/container-app.tf
@@ -139,9 +139,9 @@ resource "azurerm_container_app" "container_apps" {
         for_each = each.value == "main" && local.enable_container_health_probe ? [1] : []
 
         content {
-          interval_seconds = lookup(local.container_health_probe, "interval_seconds")
-          transport        = lookup(local.container_health_probe, "transport")
-          port             = lookup(local.container_health_probe, "port")
+          interval_seconds = lookup(local.container_health_probe, "interval_seconds", null)
+          transport        = lookup(local.container_health_probe, "transport", null)
+          port             = lookup(local.container_health_probe, "port", local.container_port)
           path             = lookup(local.container_health_probe, "path", null)
         }
       }


### PR DESCRIPTION
Issue #333 says [tflint] Lookup with 2 arguments is deprecated (terraform_deprecated_lookup) therefore, needs to be replaced with map[key] syntax which is the equivalent.