### PR TITLE
Reduce the name of the container app env storage mount

### DIFF
--- a/container-app.tf
+++ b/container-app.tf
@@ -23,7 +23,7 @@ resource "azurerm_monitor_diagnostic_setting" "container_app_env" {
 resource "azurerm_container_app_environment_storage" "container_app_env" {
   count = local.enable_container_app_file_share ? 1 : 0
 
-  name                         = "${local.resource_prefix}containerappstorage"
+  name                         = "${local.resource_prefix_sha_short}-storage"
   container_app_environment_id = azurerm_container_app_environment.container_app_env.id
   account_name                 = azurerm_storage_account.container_app[0].name
   share_name                   = azurerm_storage_share.container_app[0].name

--- a/locals.tf
+++ b/locals.tf
@@ -1,10 +1,12 @@
 locals {
   # Global options
-  environment     = var.environment
-  project_name    = var.project_name
-  resource_prefix = "${local.environment}${local.project_name}"
-  azure_location  = var.azure_location
-  tags            = var.tags
+  environment               = var.environment
+  project_name              = var.project_name
+  resource_prefix           = "${local.environment}${local.project_name}"
+  resource_prefix_sha       = sha1(local.resource_prefix)
+  resource_prefix_sha_short = substr(local.resource_prefix_sha, 0, 6)
+  azure_location            = var.azure_location
+  tags                      = var.tags
 
   # Resource Group
   existing_resource_group    = var.existing_resource_group


### PR DESCRIPTION
We don't need the word 'containerapp' or even the resource prefix in this name as it only appears in the Container App Environment as is not considered a separate resource.

Instead, to prevent name collisions, we will generate a 6 char long `sha` from the resource prefix and use the word 'storage'

Closes #353