### PR TITLE
Split File and Blob Private endpoint resources

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -67,15 +67,20 @@ locals {
     }
   } : {}
   enable_private_endpoint_storage = local.enable_storage_account ? true : false
-  private_endpoint_storage = local.enable_private_endpoint_storage ? {
-    "storage" : {
+  private_endpoint_storage_blob = local.enable_private_endpoint_storage ? {
+    "blob" : {
       resource_group : local.resource_group,
       subnet_id : azurerm_subnet.storage_private_endpoint_subnet[0].id,
       resource_id : azurerm_storage_account.container_app[0].id,
-      subresource_names : concat(
-        local.enable_container_app_blob_storage ? ["blob"] : [],
-        local.enable_container_app_file_share ? ["file"] : [],
-      )
+      subresource_names : ["blob"]
+    }
+  } : {}
+  private_endpoint_storage_file = local.enable_container_app_file_share ? {
+    "file" : {
+      resource_group : local.resource_group,
+      subnet_id : azurerm_subnet.storage_private_endpoint_subnet[0].id,
+      resource_id : azurerm_storage_account.container_app[0].id,
+      subresource_names : ["file"],
     }
   } : {}
   private_endpoints = merge(
@@ -83,7 +88,8 @@ locals {
     local.private_endpoint_mssql,
     local.private_endpoint_postgres,
     local.private_endpoint_registry,
-    local.private_endpoint_storage,
+    local.private_endpoint_storage_blob,
+    local.private_endpoint_storage_file,
   )
 
   # Azure Container Registry

--- a/virtual-network.tf
+++ b/virtual-network.tf
@@ -382,7 +382,7 @@ resource "azurerm_private_dns_a_record" "storage_private_link_blob" {
   zone_name           = azurerm_private_dns_zone.storage_private_link_blob[0].name
   resource_group_name = local.resource_group.name
   ttl                 = 300
-  records             = [azurerm_private_endpoint.default["storage"].private_service_connection[0].private_ip_address]
+  records             = [azurerm_private_endpoint.default["blob"].private_service_connection[0].private_ip_address]
   tags                = local.tags
 }
 
@@ -413,6 +413,6 @@ resource "azurerm_private_dns_a_record" "storage_private_link_file" {
   zone_name           = azurerm_private_dns_zone.storage_private_link_file[0].name
   resource_group_name = local.resource_group.name
   ttl                 = 300
-  records             = [azurerm_private_endpoint.default["storage"].private_service_connection[0].private_ip_address]
+  records             = [azurerm_private_endpoint.default["file"].private_service_connection[0].private_ip_address]
   tags                = local.tags
 }


### PR DESCRIPTION
If an operator is deploying both a File Share and a Blob Container onto the same Storage Account there is a bug that prevents the private endpoint from deploying.

Closes #352