### PR TITLE
Storage name must begin with a letter

### DIFF
--- a/container-app.tf
+++ b/container-app.tf
@@ -23,7 +23,7 @@ resource "azurerm_monitor_diagnostic_setting" "container_app_env" {
 resource "azurerm_container_app_environment_storage" "container_app_env" {
   count = local.enable_container_app_file_share ? 1 : 0
 
-  name                         = "${local.resource_prefix_sha_short}-storage"
+  name                         = "h${local.resource_prefix_sha_short}-storage"
   container_app_environment_id = azurerm_container_app_environment.container_app_env.id
   account_name                 = azurerm_storage_account.container_app[0].name
   share_name                   = azurerm_storage_share.container_app[0].name


### PR DESCRIPTION
```hcl
│ Error: "name" must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character and cannot have '--'. The length must not be more than 32 characters

│   26:   name                         = "${local.resource_prefix_sha_short}-storage"
```

because we were using a sha1 hash, it could begin with a number which broke the validation.