### PR TITLE
Metric defaults and Log table types

### DIFF
--- a/cdn.tf
+++ b/cdn.tf
@@ -361,10 +361,9 @@ resource "azurerm_cdn_frontdoor_rule" "remove_response_header" {
 resource "azurerm_monitor_diagnostic_setting" "cdn" {
   count = local.enable_cdn_frontdoor ? 1 : 0
 
-  name                           = "${local.resource_prefix}cdn"
-  target_resource_id             = azurerm_cdn_frontdoor_profile.cdn[0].id
-  log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
-  log_analytics_destination_type = "AzureDiagnostics"
+  name                       = "${local.resource_prefix}cdn"
+  target_resource_id         = azurerm_cdn_frontdoor_profile.cdn[0].id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.container_app.id
 
   dynamic "enabled_log" {
     for_each = local.cdn_frontdoor_enable_waf_logs ? [1] : []

--- a/cdn.tf
+++ b/cdn.tf
@@ -389,4 +389,10 @@ resource "azurerm_monitor_diagnostic_setting" "cdn" {
       category = "FrontdoorHealthProbeLog"
     }
   }
+
+  # The below metrics are kept in to avoid a diff in the Terraform Plan output
+  metric {
+    category = "AllMetrics"
+    enabled  = false
+  }
 }

--- a/container-app.tf
+++ b/container-app.tf
@@ -18,6 +18,12 @@ resource "azurerm_monitor_diagnostic_setting" "container_app_env" {
   enabled_log {
     category_group = "Audit"
   }
+
+  # The below metrics are kept in to avoid a diff in the Terraform Plan output
+  metric {
+    category = "AllMetrics"
+    enabled  = false
+  }
 }
 
 resource "azurerm_container_app_environment_storage" "container_app_env" {

--- a/logging.tf
+++ b/logging.tf
@@ -37,11 +37,10 @@ resource "azurerm_eventhub_namespace" "container_app" {
 resource "azurerm_monitor_diagnostic_setting" "event_hub" {
   count = local.enable_event_hub ? 1 : 0
 
-  name                           = "${local.resource_prefix}-eventhub-diag"
-  target_resource_id             = azurerm_eventhub_namespace.container_app[0].id
-  log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
-  log_analytics_destination_type = "Dedicated"
-  eventhub_name                  = azurerm_eventhub.container_app[0].name
+  name                       = "${local.resource_prefix}-eventhub-diag"
+  target_resource_id         = azurerm_eventhub_namespace.container_app[0].id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.container_app.id
+  eventhub_name              = azurerm_eventhub.container_app[0].name
 
   enabled_log {
     category_group = "Audit"

--- a/logic-app.tf
+++ b/logic-app.tf
@@ -92,13 +92,10 @@ resource "azurerm_logic_app_action_http" "slack" {
 resource "azurerm_monitor_diagnostic_setting" "webhook" {
   count = local.enable_monitoring && local.existing_logic_app_workflow.name == "" ? 1 : 0
 
-  name               = "${local.resource_prefix}-webhook-diag"
-  target_resource_id = azurerm_logic_app_workflow.webhook[0].id
-
-  log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
-  log_analytics_destination_type = "Dedicated"
-
-  eventhub_name = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
+  name                       = "${local.resource_prefix}-webhook-diag"
+  target_resource_id         = azurerm_logic_app_workflow.webhook[0].id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.container_app.id
+  eventhub_name              = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
 
   enabled_log {
     category = "WorkflowRuntime"

--- a/logic-app.tf
+++ b/logic-app.tf
@@ -103,4 +103,10 @@ resource "azurerm_monitor_diagnostic_setting" "webhook" {
   enabled_log {
     category = "WorkflowRuntime"
   }
+
+  # The below metrics are kept in to avoid a diff in the Terraform Plan output
+  metric {
+    category = "AllMetrics"
+    enabled  = false
+  }
 }

--- a/mssql.tf
+++ b/mssql.tf
@@ -46,6 +46,12 @@ resource "azurerm_monitor_diagnostic_setting" "mssql_security_storage" {
   enabled_log {
     category_group = "Audit"
   }
+
+  # The below metrics are kept in to avoid a diff in the Terraform Plan output
+  metric {
+    category = "AllMetrics"
+    enabled  = false
+  }
 }
 
 resource "azurerm_mssql_server" "default" {

--- a/mssql.tf
+++ b/mssql.tf
@@ -37,11 +37,10 @@ resource "azurerm_storage_container" "mssql_security_storage" {
 resource "azurerm_monitor_diagnostic_setting" "mssql_security_storage" {
   count = local.enable_mssql_database ? 1 : 0
 
-  name                           = "${local.resource_prefix}-mssql-blob-diag"
-  target_resource_id             = "${azurerm_storage_account.mssql_security_storage[0].id}/blobServices/default"
-  log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
-  log_analytics_destination_type = "Dedicated"
-  eventhub_name                  = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
+  name                       = "${local.resource_prefix}-mssql-blob-diag"
+  target_resource_id         = "${azurerm_storage_account.mssql_security_storage[0].id}/blobServices/default"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.container_app.id
+  eventhub_name              = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
 
   enabled_log {
     category_group = "Audit"

--- a/redis-cache.tf
+++ b/redis-cache.tf
@@ -69,4 +69,10 @@ resource "azurerm_monitor_diagnostic_setting" "default_redis_cache" {
   enabled_log {
     category = "ConnectedClientList"
   }
+
+  # The below metrics are kept in to avoid a diff in the Terraform Plan output
+  metric {
+    category = "AllMetrics"
+    enabled  = false
+  }
 }

--- a/redis-cache.tf
+++ b/redis-cache.tf
@@ -58,13 +58,10 @@ resource "azurerm_monitor_diagnostic_setting" "default_redis_cache" {
     local.enable_redis_cache ? 1 : 0
   ) : 0
 
-  name               = "${local.resource_prefix}-default-redis-diag"
-  target_resource_id = azurerm_redis_cache.default[0].id
-
-  log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
-  log_analytics_destination_type = "Dedicated"
-
-  eventhub_name = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
+  name                       = "${local.resource_prefix}-default-redis-diag"
+  target_resource_id         = azurerm_redis_cache.default[0].id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.container_app.id
+  eventhub_name              = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
 
   enabled_log {
     category = "ConnectedClientList"

--- a/storage.tf
+++ b/storage.tf
@@ -52,6 +52,16 @@ resource "azurerm_monitor_diagnostic_setting" "blobs" {
   enabled_log {
     category_group = "Audit"
   }
+
+  # The below metrics are kept in to avoid a diff in the Terraform Plan output
+  metric {
+    category = "Capacity"
+    enabled  = false
+  }
+  metric {
+    category = "Transaction"
+    enabled  = false
+  }
 }
 
 resource "azurerm_monitor_diagnostic_setting" "files" {
@@ -65,6 +75,16 @@ resource "azurerm_monitor_diagnostic_setting" "files" {
 
   enabled_log {
     category_group = "Audit"
+  }
+
+  # The below metrics are kept in to avoid a diff in the Terraform Plan output
+  metric {
+    category = "Capacity"
+    enabled  = false
+  }
+  metric {
+    category = "Transaction"
+    enabled  = false
   }
 }
 

--- a/storage.tf
+++ b/storage.tf
@@ -43,11 +43,10 @@ resource "azurerm_storage_share" "container_app" {
 resource "azurerm_monitor_diagnostic_setting" "blobs" {
   count = local.enable_container_app_blob_storage ? 1 : 0
 
-  name                           = "${local.resource_prefix}-storage-blobs-diag"
-  target_resource_id             = "${azurerm_storage_account.container_app[0].id}/blobServices/default"
-  log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
-  log_analytics_destination_type = "Dedicated"
-  eventhub_name                  = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
+  name                       = "${local.resource_prefix}-storage-blobs-diag"
+  target_resource_id         = "${azurerm_storage_account.container_app[0].id}/blobServices/default"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.container_app.id
+  eventhub_name              = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
 
   enabled_log {
     category_group = "Audit"
@@ -67,11 +66,10 @@ resource "azurerm_monitor_diagnostic_setting" "blobs" {
 resource "azurerm_monitor_diagnostic_setting" "files" {
   count = local.enable_container_app_file_share ? 1 : 0
 
-  name                           = "${local.resource_prefix}-storage-files-diag"
-  target_resource_id             = "${azurerm_storage_account.container_app[0].id}/fileServices/default"
-  log_analytics_workspace_id     = azurerm_log_analytics_workspace.container_app.id
-  log_analytics_destination_type = "Dedicated"
-  eventhub_name                  = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
+  name                       = "${local.resource_prefix}-storage-files-diag"
+  target_resource_id         = "${azurerm_storage_account.container_app[0].id}/fileServices/default"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.container_app.id
+  eventhub_name              = local.enable_event_hub ? azurerm_eventhub.container_app[0].name : null
 
   enabled_log {
     category_group = "Audit"


### PR DESCRIPTION
- Not having the disabled metrics in the Diagnostic Setting resources were causing noise in the Terraform Plan output because the value was being omitted.
- All of the resources we deploy do not support the 'Dedicated' Log Table type so it needs removing in favour of the default 'AzureDiagnostics'