### PR TITLE
Fix container replica monitor aggregation

### DIFF
--- a/monitor.tf
+++ b/monitor.tf
@@ -286,9 +286,9 @@ resource "azurerm_monitor_metric_alert" "count" {
   criteria {
     metric_namespace = "microsoft.app/containerapps"
     metric_name      = "Replicas"
-    aggregation      = "Minimum"
+    aggregation      = "Average"
     operator         = "LessThan"
-    threshold        = 1
+    threshold        = each.key == "worker_id" ? local.worker_container_min_replicas : local.container_min_replicas
   }
 
   action {


### PR DESCRIPTION
* With the aggregation set to 'Minimum' we encountered a problem when a new replica gets deployed, the previous replica gets shutdown but the metric value still tracks the old replica therefore firing the alarm. This is a false positive and not indicative of a failure scenario
* The change to move to 'Average' was suggested as a fix from Microsoft as this will be the average value across a period of time irrelevant of how many replicas get deployed.
* Setting the threshold to the min_replicas value of the Container is more useful because this allows us to determine a container failure scenario more accurately