### PR TITLE
Add support for NTLMv2

### DIFF
--- a/storage.tf
+++ b/storage.tf
@@ -32,7 +32,7 @@ resource "azurerm_storage_account" "container_app" {
 
       content {
         versions                        = ["SMB3.1.1"]
-        authentication_types            = ["Kerberos"]
+        authentication_types            = ["NTLMv2", "Kerberos"]
         kerberos_ticket_encryption_type = ["AES-256"]
         channel_encryption_type         = ["AES-128-GCM", "AES-256-GCM"]
       }


### PR DESCRIPTION
* Without this, Azure Container Apps environment (AKS) cannot mount the File Share
  * https://learn.microsoft.com/en-us/azure/storage/files/storage-how-to-use-files-linux?tabs=Ubuntu%2Csmb311
  * https://github.com/microsoft/azure-container-apps/issues/852