### PR TITLE
feat(storage): Add SAS token expiration period configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ module "azure_container_apps_hosting" {
   # container_app_blob_storage_ipv4_allow_list       = [ "8.8.8.8", "1.1.1.1" ]
   ## This will remove the automatically generated 'ConnectionStrings__BlobStorage' environment var from the Container App
   create_container_app_blob_storage_sas = false
+  ## Change the expiration date for SAS tokens. Format 'DD.HH:MM:SS'
+  # storage_account_sas_expiration_period = "00.01:00:00"
   ## Deploy a File Share
   # enable_container_app_file_share = true
   ## If you need maximum SMB compatibility for your File Share
@@ -856,6 +858,7 @@ module "azure_container_apps_hosting" {
 | <a name="input_storage_account_file_share_quota_gb"></a> [storage\_account\_file\_share\_quota\_gb](#input\_storage\_account\_file\_share\_quota\_gb) | The maximum size of the share, in gigabytes. | `number` | `2` | no |
 | <a name="input_storage_account_ipv4_allow_list"></a> [storage\_account\_ipv4\_allow\_list](#input\_storage\_account\_ipv4\_allow\_list) | A list of public IPv4 address to grant access to the Storage Account | `list(string)` | `[]` | no |
 | <a name="input_storage_account_public_access_enabled"></a> [storage\_account\_public\_access\_enabled](#input\_storage\_account\_public\_access\_enabled) | Should the Azure Storage Account have Public visibility? | `bool` | `false` | no |
+| <a name="input_storage_account_sas_expiration_period"></a> [storage\_account\_sas\_expiration\_period](#input\_storage\_account\_sas\_expiration\_period) | The SAS expiration period in format of DD.HH:MM:SS | `string` | `"02.00:00:00"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | `{}` | no |
 | <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space) | Virtual Network address space CIDR | `string` | `"172.16.0.0/12"` | no |
 | <a name="input_worker_container_command"></a> [worker\_container\_command](#input\_worker\_container\_command) | Container command for the Worker container. `enable_worker_container` must be set to true for this to have any effect. | `list(string)` | `[]` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -291,6 +291,7 @@ locals {
   ] : []
   container_app_blob_storage_public_access_enabled       = local.enable_container_app_blob_storage == false ? false : var.container_app_blob_storage_public_access_enabled
   container_app_storage_cross_tenant_replication_enabled = var.container_app_storage_cross_tenant_replication_enabled
+  storage_account_sas_expiration_period                  = var.storage_account_sas_expiration_period
   # Storage Account / File Share
   enable_container_app_file_share           = var.enable_container_app_file_share
   container_app_file_share_mount_path       = var.container_app_file_share_mount_path

--- a/mssql.tf
+++ b/mssql.tf
@@ -22,6 +22,10 @@ resource "azurerm_storage_account" "mssql_security_storage" {
       days = 7
     }
   }
+
+  sas_policy {
+    expiration_period = local.storage_account_sas_expiration_period
+  }
 }
 
 resource "azurerm_storage_account_network_rules" "mssql_security_storage" {

--- a/network-watcher.tf
+++ b/network-watcher.tf
@@ -32,6 +32,10 @@ resource "azurerm_storage_account" "default_network_watcher_nsg_flow_logs" {
     }
   }
 
+  sas_policy {
+    expiration_period = local.storage_account_sas_expiration_period
+  }
+
   tags = local.tags
 }
 

--- a/storage.tf
+++ b/storage.tf
@@ -39,6 +39,10 @@ resource "azurerm_storage_account" "container_app" {
     }
   }
 
+  sas_policy {
+    expiration_period = local.storage_account_sas_expiration_period
+  }
+
   tags = local.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1018,6 +1018,12 @@ variable "storage_account_public_access_enabled" {
   default     = false
 }
 
+variable "storage_account_sas_expiration_period" {
+  description = "The SAS expiration period in format of DD.HH:MM:SS"
+  type        = string
+  default     = "02.00:00:00"
+}
+
 variable "container_app_storage_account_shared_access_key_enabled" {
   description = "Should the storage account for the container app permit requests to be authorized with the account access key via Shared Key?"
   type        = bool


### PR DESCRIPTION
- Adds ability to set expiration period for SAS tokens on the storage accounts

I've used 2 days as the default value, as that's what the default Azure value is as far as i can tell.