### PR TITLE
[Feature] Deploy App Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,18 +617,21 @@ module "azure_container_apps_hosting" {
 | [azurerm_postgresql_flexible_server_configuration.extensions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_database.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_database) | resource |
 | [azurerm_postgresql_flexible_server_firewall_rule.firewall_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_firewall_rule) | resource |
+| [azurerm_private_dns_a_record.app_configuration_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_dns_a_record.mssql_private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_dns_a_record.postgresql_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_dns_a_record.redis_cache_private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_dns_a_record.registry_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_dns_a_record.storage_private_link_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_dns_a_record.storage_private_link_file](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
+| [azurerm_private_dns_zone.app_configuration_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone.mssql_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone.postgresql_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone.redis_cache_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone.registry_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone.storage_private_link_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone.storage_private_link_file](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.app_configuration_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.mssql_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.postgresql_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.redis_cache_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
@@ -655,6 +658,7 @@ module "azure_container_apps_hosting" {
 | [azurerm_storage_container.mssql_security_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_management_policy.mssql_security_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_management_policy) | resource |
 | [azurerm_storage_share.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_share) | resource |
+| [azurerm_subnet.app_configuration_private_endpoint_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_subnet.container_apps_infra_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_subnet.container_instances_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_subnet.mssql_private_endpoint_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
@@ -663,6 +667,7 @@ module "azure_container_apps_hosting" {
 | [azurerm_subnet.registry_private_endpoint_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_subnet.storage_private_endpoint_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_subnet_network_security_group_association.container_apps_infra](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
+| [azurerm_subnet_route_table_association.app_configuration_private_endpoint_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |
 | [azurerm_subnet_route_table_association.container_apps_infra_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |
 | [azurerm_subnet_route_table_association.containerinstances_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |
 | [azurerm_subnet_route_table_association.mssql_private_endpoint_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |

--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ module "azure_container_apps_hosting" {
 | [azapi_update_resource.mssql_security_storage_key_rotation_reminder](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) | resource |
 | [azapi_update_resource.mssql_threat_protection](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) | resource |
 | [azapi_update_resource.mssql_vulnerability_assessment](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) | resource |
+| [azurerm_app_configuration.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_configuration) | resource |
 | [azurerm_application_insights.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights) | resource |
 | [azurerm_application_insights_standard_web_test.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights_standard_web_test) | resource |
 | [azurerm_application_insights_standard_web_test.tls](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights_standard_web_test) | resource |
@@ -688,6 +689,7 @@ module "azure_container_apps_hosting" {
 | <a name="input_alarm_log_ingestion_gb_per_day"></a> [alarm\_log\_ingestion\_gb\_per\_day](#input\_alarm\_log\_ingestion\_gb\_per\_day) | Define an alarm threshold for Log Analytics ingestion rate in GB (per day) (Defaults to no limit) | `number` | `0` | no |
 | <a name="input_alarm_memory_threshold_percentage"></a> [alarm\_memory\_threshold\_percentage](#input\_alarm\_memory\_threshold\_percentage) | Specify a number (%) which should be set as a threshold for a memory usage monitoring alarm | `number` | `80` | no |
 | <a name="input_alarm_tls_expiry_days_remaining"></a> [alarm\_tls\_expiry\_days\_remaining](#input\_alarm\_tls\_expiry\_days\_remaining) | Number of days remaining of TLS validity before an alarm should be raised | `number` | `30` | no |
+| <a name="input_app_configuration_sku"></a> [app\_configuration\_sku](#input\_app\_configuration\_sku) | The SKU name of the App Configuration. Possible values are free and standard. Defaults to free. | `string` | `"free"` | no |
 | <a name="input_app_insights_retention_days"></a> [app\_insights\_retention\_days](#input\_app\_insights\_retention\_days) | Number of days to retain App Insights data for (Default: 2 years) | `number` | `730` | no |
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Azure location in which to launch resources. | `string` | n/a | yes |
 | <a name="input_cdn_frontdoor_custom_domains"></a> [cdn\_frontdoor\_custom\_domains](#input\_cdn\_frontdoor\_custom\_domains) | Azure CDN Front Door custom domains | `list(string)` | `[]` | no |
@@ -755,6 +757,7 @@ module "azure_container_apps_hosting" {
 | <a name="input_dns_txt_records"></a> [dns\_txt\_records](#input\_dns\_txt\_records) | DNS TXT records to add to the DNS Zone | <pre>map(<br>    object({<br>      ttl : optional(number, 300),<br>      records : list(string)<br>    })<br>  )</pre> | `{}` | no |
 | <a name="input_dns_zone_domain_name"></a> [dns\_zone\_domain\_name](#input\_dns\_zone\_domain\_name) | DNS zone domain name. If created, records will automatically be created to point to the CDN. | `string` | `""` | no |
 | <a name="input_dns_zone_soa_record"></a> [dns\_zone\_soa\_record](#input\_dns\_zone\_soa\_record) | DNS zone SOA record block (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_zone#soa_record) | `map(string)` | `{}` | no |
+| <a name="input_enable_app_configuration"></a> [enable\_app\_configuration](#input\_enable\_app\_configuration) | Deploy an Azure App Configuration resource | `bool` | `false` | no |
 | <a name="input_enable_app_insights_integration"></a> [enable\_app\_insights\_integration](#input\_enable\_app\_insights\_integration) | Deploy an App Insights instance and connect your Container Apps to it | `bool` | `true` | no |
 | <a name="input_enable_cdn_frontdoor"></a> [enable\_cdn\_frontdoor](#input\_enable\_cdn\_frontdoor) | Enable Azure CDN Front Door. This will use the Container Apps endpoint as the origin. | `bool` | `false` | no |
 | <a name="input_enable_cdn_frontdoor_health_probe"></a> [enable\_cdn\_frontdoor\_health\_probe](#input\_enable\_cdn\_frontdoor\_health\_probe) | Enable CDN Front Door health probe | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ module "azure_container_apps_hosting" {
 | [azurerm_redis_firewall_rule.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_firewall_rule) | resource |
 | [azurerm_resource_group.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.containerapp_acrpull](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.containerapp_appconfig_read](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.kv_secret_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.mssql_storageblobdatacontributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_route_table.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route_table) | resource |
@@ -689,6 +690,7 @@ module "azure_container_apps_hosting" {
 | <a name="input_alarm_log_ingestion_gb_per_day"></a> [alarm\_log\_ingestion\_gb\_per\_day](#input\_alarm\_log\_ingestion\_gb\_per\_day) | Define an alarm threshold for Log Analytics ingestion rate in GB (per day) (Defaults to no limit) | `number` | `0` | no |
 | <a name="input_alarm_memory_threshold_percentage"></a> [alarm\_memory\_threshold\_percentage](#input\_alarm\_memory\_threshold\_percentage) | Specify a number (%) which should be set as a threshold for a memory usage monitoring alarm | `number` | `80` | no |
 | <a name="input_alarm_tls_expiry_days_remaining"></a> [alarm\_tls\_expiry\_days\_remaining](#input\_alarm\_tls\_expiry\_days\_remaining) | Number of days remaining of TLS validity before an alarm should be raised | `number` | `30` | no |
+| <a name="input_app_configuration_assign_role"></a> [app\_configuration\_assign\_role](#input\_app\_configuration\_assign\_role) | Assign the 'App Configuration Data Reader' Role to the Container App User-Assigned Managed Identity. Note: If you do not have 'Microsoft.Authorization/roleAssignments/write' permission, you will need to manually assign the 'App Configuration Data Reader' Role to the identity | `bool` | `false` | no |
 | <a name="input_app_configuration_sku"></a> [app\_configuration\_sku](#input\_app\_configuration\_sku) | The SKU name of the App Configuration. Possible values are free and standard. Defaults to free. | `string` | `"free"` | no |
 | <a name="input_app_insights_retention_days"></a> [app\_insights\_retention\_days](#input\_app\_insights\_retention\_days) | Number of days to retain App Insights data for (Default: 2 years) | `number` | `730` | no |
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Azure location in which to launch resources. | `string` | n/a | yes |

--- a/app-configuration.tf
+++ b/app-configuration.tf
@@ -6,7 +6,7 @@ resource "azurerm_app_configuration" "default" {
   location              = local.resource_group.location
   sku                   = local.app_configuration_sku
   local_auth_enabled    = true
-  public_network_access = "Disabled"
+  public_network_access = local.app_configuration_sku == "free" ? "Enabled" : "Disabled"
 
   tags = local.tags
 }

--- a/app-configuration.tf
+++ b/app-configuration.tf
@@ -1,0 +1,12 @@
+resource "azurerm_app_configuration" "default" {
+  count = local.enable_app_configuration ? 1 : 0
+
+  name                  = "${local.resource_prefix}appconfig"
+  resource_group_name   = local.resource_group.name
+  location              = local.resource_group.location
+  sku                   = local.app_configuration_sku
+  local_auth_enabled    = true
+  public_network_access = "Disabled"
+
+  tags = local.tags
+}

--- a/app-configuration.tf
+++ b/app-configuration.tf
@@ -10,3 +10,12 @@ resource "azurerm_app_configuration" "default" {
 
   tags = local.tags
 }
+
+resource "azurerm_role_assignment" "containerapp_appconfig_read" {
+  count = local.enable_app_configuration && local.app_configuration_assign_role ? 1 : 0
+
+  scope                = azurerm_app_configuration.default[0].id
+  role_definition_name = "App Configuration Data Reader"
+  principal_id         = azurerm_user_assigned_identity.containerapp[0].id
+  description          = "Allow Azure Container Apps to read data from App Configuration"
+}

--- a/container-app.tf
+++ b/container-app.tf
@@ -159,6 +159,12 @@ resource "azurerm_container_app" "container_apps" {
               "secretRef" : "connectionstrings--redis"
             }
           ] : [],
+          local.enable_app_configuration ? [
+            {
+              "name"      = "ConnectionStrings__AppConfig",
+              "secretRef" = "connectionstrings--appconfig"
+            }
+          ] : [],
           [
             for env_name, env_value in local.container_environment_variables : {
               name  = env_name

--- a/locals.tf
+++ b/locals.tf
@@ -415,4 +415,8 @@ locals {
     local.network_security_group_container_apps_infra_id,
   )
   network_watcher_nsg_storage_access_key_rotation_reminder_days = var.network_watcher_nsg_storage_access_key_rotation_reminder_days != 0 ? var.network_watcher_nsg_storage_access_key_rotation_reminder_days : local.storage_account_access_key_rotation_reminder_days
+
+  # App Configuration
+  enable_app_configuration = var.enable_app_configuration
+  app_configuration_sku    = var.app_configuration_sku
 }

--- a/locals.tf
+++ b/locals.tf
@@ -211,6 +211,12 @@ locals {
         value = azurerm_redis_cache.default[0].primary_connection_string
       }
     ] : [],
+    local.enable_app_configuration ? [
+      {
+        name  = "connectionstrings--appconfig",
+        value = azurerm_app_configuration.default[0].endpoint
+      }
+    ] : [],
     local.container_app_blob_storage_sas_secret,
     [for env_name, env_value in nonsensitive(local.container_secret_environment_variables) : {
       name  = lower(replace(env_name, "_", "-"))

--- a/locals.tf
+++ b/locals.tf
@@ -423,6 +423,7 @@ locals {
   network_watcher_nsg_storage_access_key_rotation_reminder_days = var.network_watcher_nsg_storage_access_key_rotation_reminder_days != 0 ? var.network_watcher_nsg_storage_access_key_rotation_reminder_days : local.storage_account_access_key_rotation_reminder_days
 
   # App Configuration
-  enable_app_configuration = var.enable_app_configuration
-  app_configuration_sku    = var.app_configuration_sku
+  enable_app_configuration      = var.enable_app_configuration
+  app_configuration_sku         = var.app_configuration_sku
+  app_configuration_assign_role = var.app_configuration_assign_role
 }

--- a/locals.tf
+++ b/locals.tf
@@ -33,6 +33,7 @@ locals {
   redis_cache_subnet_cidr                                  = cidrsubnet(local.virtual_network_address_space, 23 - local.virtual_network_address_space_mask, 4)
   postgresql_subnet_cidr                                   = cidrsubnet(local.virtual_network_address_space, 23 - local.virtual_network_address_space_mask, 5)
   storage_subnet_cidr                                      = cidrsubnet(local.virtual_network_address_space, 23 - local.virtual_network_address_space_mask, 6)
+  app_configuration_subnet_cidr                            = cidrsubnet(local.virtual_network_address_space, 23 - local.virtual_network_address_space_mask, 7)
   container_app_environment_internal_load_balancer_enabled = var.container_app_environment_internal_load_balancer_enabled
   container_apps_infra_subnet_service_endpoints = distinct(concat(
     local.launch_in_vnet && local.enable_storage_account ? ["Microsoft.Storage"] : [],
@@ -96,6 +97,14 @@ locals {
       subresource_names : ["file"],
     }
   } : {}
+  enable_private_endpoint_app_configuration = local.enable_app_configuration ? true : false
+  private_endpoint_app_configuration = local.enable_private_endpoint_app_configuration ? {
+    "appconfig" : {
+      resource_group : local.resource_group,
+      subnet_id : azurerm_subnet.app_configuration_private_endpoint_subnet[0].id,
+      resource_id : azurerm_app_configuration.default[0].id,
+    }
+  } : {}
   private_endpoints = merge(
     local.private_endpoint_redis,
     local.private_endpoint_mssql,
@@ -103,6 +112,7 @@ locals {
     local.private_endpoint_registry,
     local.private_endpoint_storage_blob,
     local.private_endpoint_storage_file,
+    local.private_endpoint_app_configuration,
   )
 
   # Azure Container Registry

--- a/locals.tf
+++ b/locals.tf
@@ -97,7 +97,7 @@ locals {
       subresource_names : ["file"],
     }
   } : {}
-  enable_private_endpoint_app_configuration = local.enable_app_configuration ? true : false
+  enable_private_endpoint_app_configuration = local.enable_app_configuration && local.app_configuration_sku != "free" ? true : false
   private_endpoint_app_configuration = local.enable_private_endpoint_app_configuration ? {
     "appconfig" : {
       resource_group : local.resource_group,

--- a/variables.tf
+++ b/variables.tf
@@ -1200,3 +1200,9 @@ variable "app_configuration_sku" {
   type        = string
   default     = "free"
 }
+
+variable "app_configuration_assign_role" {
+  description = "Assign the 'App Configuration Data Reader' Role to the Container App User-Assigned Managed Identity. Note: If you do not have 'Microsoft.Authorization/roleAssignments/write' permission, you will need to manually assign the 'App Configuration Data Reader' Role to the identity"
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1188,3 +1188,15 @@ variable "container_app_file_share_security_profile" {
     error_message = "Valid values for container_app_file_share_security_profile are 'security' or 'compatibility'."
   }
 }
+
+variable "enable_app_configuration" {
+  description = "Deploy an Azure App Configuration resource"
+  type        = bool
+  default     = false
+}
+
+variable "app_configuration_sku" {
+  description = "The SKU name of the App Configuration. Possible values are free and standard. Defaults to free."
+  type        = string
+  default     = "free"
+}


### PR DESCRIPTION
Allow operators to deploy an App Configuration resource for centrally managing app settings and feature flags that are not intended to be managed by terraform.

https://learn.microsoft.com/en-us/azure/azure-app-configuration/overview
https://learn.microsoft.com/en-us/azure/azure-app-configuration/quickstart-container-apps?tabs=azure-portal#connect-azure-app-configuration-to-the-container-app

Closes https://github.com/DFE-Digital/terraform-azurerm-container-apps-hosting/issues/403