### PR TITLE
[Identity] Container App Identity is now unlinked from ACR

### DIFF
--- a/container-app.tf
+++ b/container-app.tf
@@ -81,16 +81,7 @@ resource "azurerm_container_app" "container_apps" {
   }
 
   dynamic "identity" {
-    for_each = local.registry_use_managed_identity ? [1] : []
-
-    content {
-      type         = "UserAssigned"
-      identity_ids = [azurerm_user_assigned_identity.containerapp[0].id]
-    }
-  }
-
-  dynamic "identity" {
-    for_each = local.container_app_identities != null ? [1] : []
+    for_each = local.container_app_identities
 
     content {
       type         = local.container_app_identities.type

--- a/identity.tf
+++ b/identity.tf
@@ -1,5 +1,5 @@
 resource "azurerm_user_assigned_identity" "containerapp" {
-  count = local.registry_use_managed_identity ? 1 : 0
+  count = local.enable_container_app_uami ? 1 : 0
 
   location            = local.resource_group.location
   name                = "${local.resource_prefix}-uami-containerapp"


### PR DESCRIPTION
When we originally deployed the UAMI, it was because we were only using it to pull images from ACR. Now the UAMI is used for lots of other things so the two resources should be uncoupled.