### PR TITLE
Add Identity client Id to env vars

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -268,6 +268,12 @@ locals {
         "secretRef" : "connectionstrings--appconfig"
       }
     ] : [],
+    local.enable_container_app_uami ? [
+      {
+        "name" : "AZURE_CLIENT_ID"
+        "value" : azurerm_user_assigned_identity.containerapp[0].client_id
+      }
+    ] : [],
     [
       for env_name, env_value in local.container_environment_variables : {
         name  = env_name


### PR DESCRIPTION
Microsoft packages can only inherit the use of a System Assigned Managed Identity automatically. In our use case, we register a User Assigned Managed Identity. To expose this to the running app, we can set an environment variable 