### PR TITLE
Fix: Invalid list reference

### DIFF
--- a/container-app.tf
+++ b/container-app.tf
@@ -81,11 +81,11 @@ resource "azurerm_container_app" "container_apps" {
   }
 
   dynamic "identity" {
-    for_each = toset(local.container_app_identity_ids)
+    for_each = length(local.container_app_identity_ids) > 0 ? [1] : []
 
     content {
       type         = "UserAssigned"
-      identity_ids = identity.value
+      identity_ids = local.container_app_identity_ids
     }
   }
 


### PR DESCRIPTION
The `identity` block can only have 1, so we assign multiple IDs in the nested property