### PR TITLE
SQL server names missing from monitors

### DIFF
--- a/monitor.tf
+++ b/monitor.tf
@@ -123,10 +123,10 @@ resource "azurerm_monitor_metric_alert" "count" {
 resource "azurerm_monitor_metric_alert" "sql_cpu" {
   count = local.enable_monitoring && local.enable_mssql_database ? 1 : 0
 
-  name                = "SQL CPU Usage - ${azurerm_mssql_database.default[0].name}"
+  name                = "SQL Database CPU - ${azurerm_mssql_server.default[0].name}/${azurerm_mssql_database.default[0].name}"
   resource_group_name = local.resource_group.name
   scopes              = [azurerm_mssql_database.default[0].id]
-  description         = "Azure SQL Server ${azurerm_mssql_database.default[0].name} is consuming more than 80% of CPU"
+  description         = "SQL Database ${azurerm_mssql_server.default[0].name}/${azurerm_mssql_database.default[0].name} is consuming more than 80% of CPU"
   window_size         = "PT5M"
   frequency           = "PT5M"
   severity            = 2 # Warning
@@ -149,10 +149,10 @@ resource "azurerm_monitor_metric_alert" "sql_cpu" {
 resource "azurerm_monitor_metric_alert" "sql_dtu" {
   count = local.enable_monitoring && local.enable_mssql_database ? 1 : 0
 
-  name                = "SQL DTU Usage - ${azurerm_mssql_database.default[0].name}"
+  name                = "SQL Database DTU - ${azurerm_mssql_server.default[0].name}/${azurerm_mssql_database.default[0].name}"
   resource_group_name = local.resource_group.name
   scopes              = [azurerm_mssql_database.default[0].id]
-  description         = "Azure SQL Server ${azurerm_mssql_database.default[0].name} is consuming more than 80% of available DTUs"
+  description         = "SQL Database ${azurerm_mssql_server.default[0].name}/${azurerm_mssql_database.default[0].name} is consuming more than 80% of available DTUs"
   window_size         = "PT5M"
   frequency           = "PT5M"
   severity            = 2 # Warning


### PR DESCRIPTION
- In Azure, the Database is used for scoping the alert, but it is often represented in the format `<server>/<database>` so i've updated the Alert to match