### PR TITLE
fix: Handle container_app_uami being null

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,12 +485,11 @@ module "azure_container_apps_hosting" {
   # enable_network_watcher_traffic_analytics   = true
   # network_watcher_traffic_analytics_interval = 60
 
-  ## Use a user assigned or system assigned identity on the Container App
-  #   container_app_identities = {
-  #   type         = "UserAssigned", # Accepted values: "UserAssigned", "SystemAssigned", "SystemAssigned, UserAssigned"
-  #   identity_ids = [azurerm_user_assigned_identity.user_assigned_identity.id]
-  # }
+  ## Use a user assigned identity on the Container App.
+  # container_app_identities = [azurerm_user_assigned_identity.user_assigned_identity.id]
 
+  # A user assigned managed identity is created for the container app by default, but can be disabled.
+  # container_app_use_managed_identity = false
 
   # Tags are applied to every resource deployed by this module
   # Include them as Key:Value pairs

--- a/locals.tf
+++ b/locals.tf
@@ -237,6 +237,7 @@ locals {
     key_vault_secret_id = azurerm_key_vault_secret.secret_app_setting[name].versionless_id
     name                = secret["name"]
   } } : {}
+  container_app_client_id_value = local.enable_container_app_uami ? azurerm_user_assigned_identity.containerapp[0].client_id : length(var.container_app_identities) == 1 ? var.container_app_identities[0] : null
   container_app_env_vars = { for i, v in concat(
     local.enable_app_insights_integration ? [
       {
@@ -268,10 +269,10 @@ locals {
         "secretRef" : "connectionstrings--appconfig"
       }
     ] : [],
-    local.enable_container_app_uami ? [
+    local.container_app_client_id_value != null ? [
       {
         "name" : "AZURE_CLIENT_ID"
-        "value" : azurerm_user_assigned_identity.containerapp[0].client_id
+        "value" : local.container_app_client_id_value
       }
     ] : [],
     [

--- a/locals.tf
+++ b/locals.tf
@@ -301,7 +301,7 @@ locals {
   ])
   container_app_uami = local.enable_container_app_uami ? azurerm_user_assigned_identity.containerapp[0].id : null
   container_app_identity_ids = concat(
-    var.container_app_identities, [local.container_app_uami]
+    var.container_app_identities, local.container_app_uami != null ? [local.container_app_uami] : []
   )
 
   # Container App / Container image


### PR DESCRIPTION
# Problem

When `local.enable_container_app_uami` is `false`, then `local.container_app_uami` is set as `null`. Consequently, `container_app_identity_ids` ends up having a null value in it.

This is not allowed by the TF provider, assumedly because you can't set a null identity.

# Fix

- Add a null check to `local.container_app_uami` before adding to `local.container_app_identity_ids`

# Other changes

- Created a `local.container_app_client_id_value` variable. This i set as:
    1. `azurerm_user_assigned_identity.containerapp[0].client_id` if `local.enable_container_app_uami` is `true`
   2. Otherwise, if `var.container_app_identities` has exactly one identity in it, then that value is used
   3. Otherwise, null

 - Change the value of `AZURE_CLIENT_ID` in the container app environment variables (`local.container_app_env_vars`) to `local.container_app_client_id_value` (if not null - otherwise don't create the AZURE_CLIENT_ID variable)


- Update README for the change to `var.container_app_identities`
- Add an example of disabling `var.container_app_use_managed_identity` to the README
