### PR TITLE
fix(mi): revert client id change

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -237,7 +237,7 @@ locals {
     key_vault_secret_id = azurerm_key_vault_secret.secret_app_setting[name].versionless_id
     name                = secret["name"]
   } } : {}
-  container_app_client_id_value = local.enable_container_app_uami ? azurerm_user_assigned_identity.containerapp[0].client_id : length(var.container_app_identities) == 1 ? var.container_app_identities[0] : null
+
   container_app_env_vars = { for i, v in concat(
     local.enable_app_insights_integration ? [
       {
@@ -269,10 +269,10 @@ locals {
         "secretRef" : "connectionstrings--appconfig"
       }
     ] : [],
-    local.container_app_client_id_value != null ? [
+    local.enable_container_app_uami ? [
       {
         "name" : "AZURE_CLIENT_ID"
-        "value" : local.container_app_client_id_value
+        "value" : local.container_app_uami
       }
     ] : [],
     [


### PR DESCRIPTION
Reverts a previous change where `var.container_app_identities` would be used for `AZURE_CLIENT_ID` on the container app under certain conditions.

Completely missed the fact that:
- `var.container_app_identities` takes the Azure resource ID (e.g. `/subscriptions/.....`
- but `AZURE_CLIENT_ID` needs, well, the managed identity client ID

I debated making this a new variable and setting it that way, but IMO leaving it like this means that it is easy to just set `AZURE_CLIENT_ID` yourself, to whatever value you want, by adding it to `var.container_environment_variables`.