### PR TITLE
Alert Rules for deletion activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,13 @@ module "azure_container_apps_hosting" {
 | [azurerm_log_analytics_workspace.function_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_management_lock.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) | resource |
 | [azurerm_monitor_action_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
+| [azurerm_monitor_activity_log_alert.delete_container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_activity_log_alert) | resource |
+| [azurerm_monitor_activity_log_alert.delete_dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_activity_log_alert) | resource |
+| [azurerm_monitor_activity_log_alert.delete_frontdoor_cdn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_activity_log_alert) | resource |
+| [azurerm_monitor_activity_log_alert.delete_postgresql_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_activity_log_alert) | resource |
+| [azurerm_monitor_activity_log_alert.delete_redis_cache](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_activity_log_alert) | resource |
+| [azurerm_monitor_activity_log_alert.delete_sql_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_activity_log_alert) | resource |
+| [azurerm_monitor_activity_log_alert.delete_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_activity_log_alert) | resource |
 | [azurerm_monitor_diagnostic_setting.blobs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.cdn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.container_app_env](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
@@ -739,6 +746,7 @@ module "azure_container_apps_hosting" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alarm_cpu_threshold_percentage"></a> [alarm\_cpu\_threshold\_percentage](#input\_alarm\_cpu\_threshold\_percentage) | Specify a number (%) which should be set as a threshold for a CPU usage monitoring alarm | `number` | `80` | no |
+| <a name="input_alarm_for_delete_events"></a> [alarm\_for\_delete\_events](#input\_alarm\_for\_delete\_events) | Should Alert Rules be created for Administrative 'Delete' actions? | `bool` | `true` | no |
 | <a name="input_alarm_latency_threshold_ms"></a> [alarm\_latency\_threshold\_ms](#input\_alarm\_latency\_threshold\_ms) | Specify a number in milliseconds which should be set as a threshold for a request latency monitoring alarm | `number` | `1000` | no |
 | <a name="input_alarm_log_ingestion_gb_per_day"></a> [alarm\_log\_ingestion\_gb\_per\_day](#input\_alarm\_log\_ingestion\_gb\_per\_day) | Define an alarm threshold for Log Analytics ingestion rate in GB (per day) (Defaults to no limit) | `number` | `0` | no |
 | <a name="input_alarm_memory_threshold_percentage"></a> [alarm\_memory\_threshold\_percentage](#input\_alarm\_memory\_threshold\_percentage) | Specify a number (%) which should be set as a threshold for a memory usage monitoring alarm | `number` | `80` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -506,6 +506,7 @@ locals {
   alarm_memory_threshold_percentage = var.alarm_memory_threshold_percentage
   alarm_latency_threshold_ms        = var.alarm_latency_threshold_ms
   alarm_log_ingestion_gb_per_day    = var.alarm_log_ingestion_gb_per_day
+  alarm_for_delete_events           = var.alarm_for_delete_events
 
   # Network Watcher
   enable_network_watcher                         = var.enable_network_watcher

--- a/monitor.tf
+++ b/monitor.tf
@@ -563,3 +563,164 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "log-analytics-ingesti
 
   tags = local.tags
 }
+
+resource "azurerm_monitor_activity_log_alert" "delete_container_app" {
+  for_each = local.alarm_for_delete_events ? merge(azurerm_container_app.container_apps, azurerm_container_app.custom_container_apps) : {}
+
+  name                = "Resource Deletion - Container App - ${each.value.name}"
+  resource_group_name = local.resource_group.name
+  location            = local.resource_group.location
+  scopes              = [local.resource_group.id]
+  description         = "Delete Resource event started for Container App ${each.value.name}"
+
+  criteria {
+    resource_id    = each.value.id
+    operation_name = "microsoft.app/containerapps/delete"
+    category       = "Administrative"
+    statuses       = ["Started"]
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main[0].id
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_activity_log_alert" "delete_sql_database" {
+  count = local.alarm_for_delete_events && local.enable_mssql_database ? 1 : 0
+
+  name                = "Resource Deletion - SQL Database - ${azurerm_mssql_database.default[0].name}"
+  resource_group_name = local.resource_group.name
+  location            = local.resource_group.location
+  scopes              = [local.resource_group.id]
+  description         = "Delete Resource event started for SQL Database ${azurerm_mssql_database.default[0].name}"
+
+  criteria {
+    resource_id    = azurerm_mssql_database.default[0].id
+    operation_name = "microsoft.sql/servers/databases/delete"
+    category       = "Administrative"
+    statuses       = ["Started"]
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main[0].id
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_activity_log_alert" "delete_dns_zone" {
+  count = local.alarm_for_delete_events && local.enable_dns_zone ? 1 : 0
+
+  name                = "Resource Deletion - DNS Zone - ${azurerm_dns_zone.default[0].name}"
+  resource_group_name = local.resource_group.name
+  location            = local.resource_group.location
+  scopes              = [local.resource_group.id]
+  description         = "Delete Resource event started for DNS Zone ${azurerm_dns_zone.default[0].name}"
+
+  criteria {
+    resource_id    = azurerm_dns_zone.default[0].id
+    operation_name = "microsoft.network/dnszones/delete"
+    category       = "Administrative"
+    statuses       = ["Started"]
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main[0].id
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_activity_log_alert" "delete_redis_cache" {
+  count = local.alarm_for_delete_events && local.enable_redis_cache ? 1 : 0
+
+  name                = "Resource Deletion - Redis Cache - ${azurerm_redis_cache.default[0].name}"
+  resource_group_name = local.resource_group.name
+  location            = local.resource_group.location
+  scopes              = [local.resource_group.id]
+  description         = "Delete Resource event started for Redis Cache ${azurerm_redis_cache.default[0].name}"
+
+  criteria {
+    resource_id    = azurerm_redis_cache.default[0].id
+    operation_name = "microsoft.cache/redis/delete"
+    category       = "Administrative"
+    statuses       = ["Started"]
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main[0].id
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_activity_log_alert" "delete_postgresql_database" {
+  count = local.alarm_for_delete_events && local.enable_postgresql_database ? 1 : 0
+
+  name                = "Resource Deletion - PostgreSQL Database - ${azurerm_postgresql_flexible_server_database.default[0].name}"
+  resource_group_name = local.resource_group.name
+  location            = local.resource_group.location
+  scopes              = [local.resource_group.id]
+  description         = "Delete Resource event started for PostgreSQL Database ${azurerm_postgresql_flexible_server_database.default[0].name}"
+
+  criteria {
+    resource_id    = azurerm_postgresql_flexible_server_database.default[0].id
+    operation_name = "microsoft.dbforpostgresql/servers/databases/delete"
+    category       = "Administrative"
+    statuses       = ["Started"]
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main[0].id
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_activity_log_alert" "delete_frontdoor_cdn" {
+  count = local.alarm_for_delete_events && local.enable_cdn_frontdoor ? 1 : 0
+
+  name                = "Resource Deletion - Front Door - ${azurerm_cdn_frontdoor_profile.cdn[0].name}"
+  resource_group_name = local.resource_group.name
+  location            = local.resource_group.location
+  scopes              = [local.resource_group.id]
+  description         = "Delete Resource event started for Front Door ${azurerm_cdn_frontdoor_profile.cdn[0].name}"
+
+  criteria {
+    resource_id    = azurerm_cdn_frontdoor_profile.cdn[0].id
+    operation_name = "microsoft.cdn/profiles/delete"
+    category       = "Administrative"
+    statuses       = ["Started"]
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main[0].id
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_activity_log_alert" "delete_vnet" {
+  count = local.alarm_for_delete_events && local.launch_in_vnet ? 1 : 0
+
+  name                = "Resource Deletion - Virtual Network - ${local.virtual_network.name}"
+  resource_group_name = local.resource_group.name
+  location            = local.resource_group.location
+  scopes              = [local.resource_group.id]
+  description         = "Delete Resource event started for Virtual Network ${local.virtual_network.name}"
+
+  criteria {
+    resource_id    = local.virtual_network.id
+    operation_name = "microsoft.network/virtualnetworks/delete"
+    category       = "Administrative"
+    statuses       = ["Started"]
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main[0].id
+  }
+
+  tags = local.tags
+}

--- a/variables.tf
+++ b/variables.tf
@@ -910,6 +910,12 @@ variable "monitor_endpoint_healthcheck" {
   default     = "/"
 }
 
+variable "alarm_for_delete_events" {
+  description = "Should Alert Rules be created for Administrative 'Delete' actions?"
+  type        = bool
+  default     = true
+}
+
 variable "alarm_log_ingestion_gb_per_day" {
   description = "Define an alarm threshold for Log Analytics ingestion rate in GB (per day) (Defaults to no limit)"
   type        = number


### PR DESCRIPTION
- For auditing purposes one might find it beneficial to enable Alert Rules that fire when an Administrative task starts in Azure.
- Setting var.alarm_for_delete_events to true will conditionally deploy a number of alert rules for services that are launched by Terraform