### PR TITLE
Use Client ID in env vars + Resource ID in Identity map

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -272,7 +272,7 @@ locals {
     local.enable_container_app_uami ? [
       {
         "name" : "AZURE_CLIENT_ID"
-        "value" : local.container_app_uami
+        "value" : local.container_app_uami.client_id
       }
     ] : [],
     [
@@ -300,9 +300,9 @@ locals {
     local.key_vault != null,
     local.enable_storage_account,
   ])
-  container_app_uami = local.enable_container_app_uami ? azurerm_user_assigned_identity.containerapp[0].id : null
+  container_app_uami = local.enable_container_app_uami ? azurerm_user_assigned_identity.containerapp[0] : null
   container_app_identity_ids = concat(
-    var.container_app_identities, local.container_app_uami != null ? [local.container_app_uami] : []
+    var.container_app_identities, local.container_app_uami != null ? [local.container_app_uami.id] : []
   )
 
   # Container App / Container image


### PR DESCRIPTION
Make `local.container_app_uami` reference the parent object so we can pull relevant properties out of it