### PR TITLE
Stabilised version constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,19 +521,19 @@ module "azure_container_apps_hosting" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.5, < 2.0.0 |
-| <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.6.0 |
-| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 1.13.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.0.0, < 5.0.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.9 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.6 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 1.13 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.6.0 |
-| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | >= 1.13.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.0.0, < 5.0.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.6 |
+| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | ~> 1.13 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Resources

--- a/versions.tf
+++ b/versions.tf
@@ -1,21 +1,25 @@
 terraform {
-  required_version = ">= 1.9.5, < 2.0.0"
+  required_version = "~> 1.9"
+
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 4.0"
     }
+
     azapi = {
       source  = "Azure/azapi"
-      version = ">= 1.13.0"
+      version = "~> 1.13"
     }
+
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.2.1"
+      version = "~> 3.2"
     }
+
     archive = {
       source  = "hashicorp/archive"
-      version = ">= 2.6.0"
+      version = "~> 2.6"
     }
   }
 }


### PR DESCRIPTION
~> | Allows only the right-most version component to increment. 

Examples: `~> 1.0`: Allows Terraform to install 1.1 and 1.2.1 but not 2.0.

