### PR TITLE
[145886] Alert on error logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ module "azure_container_apps_hosting" {
 | [azurerm_monitor_metric_alert.sql_dtu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.exceptions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.log-analytics-ingestion](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.traces](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.ai_smart_dependency_degradation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.ai_smart_exception_volume](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |
 | [azurerm_monitor_smart_detector_alert_rule.ai_smart_failures](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_smart_detector_alert_rule) | resource |
@@ -838,6 +839,8 @@ module "azure_container_apps_hosting" {
 | <a name="input_enable_init_container"></a> [enable\_init\_container](#input\_enable\_init\_container) | Deploy an Init Container. Init containers run before the primary app container and are used to perform initialization tasks such as downloading data or preparing the environment | `bool` | `false` | no |
 | <a name="input_enable_logstash_consumer"></a> [enable\_logstash\_consumer](#input\_enable\_logstash\_consumer) | Create an Event Hub consumer group for Logstash | `bool` | `false` | no |
 | <a name="input_enable_monitoring"></a> [enable\_monitoring](#input\_enable\_monitoring) | Create an App Insights instance and notification group for the Container App | `bool` | `false` | no |
+| <a name="input_enable_monitoring_traces"></a> [enable\_monitoring\_traces](#input\_enable\_monitoring\_traces) | Monitor App Insights traces for error messages | `bool` | `false` | no |
+| <a name="input_enable_monitoring_traces_include_warnings"></a> [enable\_monitoring\_traces\_include\_warnings](#input\_enable\_monitoring\_traces\_include\_warnings) | Extend the App Insights trace monitor to include warning messages (warning: could be noisy!) | `bool` | `false` | no |
 | <a name="input_enable_mssql_database"></a> [enable\_mssql\_database](#input\_enable\_mssql\_database) | Set to true to create an Azure SQL server/database, with a private endpoint within the virtual network | `bool` | `false` | no |
 | <a name="input_enable_mssql_vulnerability_assessment"></a> [enable\_mssql\_vulnerability\_assessment](#input\_enable\_mssql\_vulnerability\_assessment) | Vulnerability assessment can discover, track, and help you remediate potential database vulnerabilities | `bool` | `true` | no |
 | <a name="input_enable_network_watcher"></a> [enable\_network\_watcher](#input\_enable\_network\_watcher) | Enable network watcher. Note: only 1 network watcher per subscription can be created. | `bool` | `false` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -505,6 +505,9 @@ locals {
     resource_id  = local.logic_app_workflow_id
     callback_url = local.logic_app_workflow_callback_url
   }
+  enable_monitoring_traces                  = var.enable_monitoring_traces
+  enable_monitoring_traces_include_warnings = var.enable_monitoring_traces_include_warnings
+
   # Azure Monitor / Alarm thresholds
   alarm_cpu_threshold_percentage    = var.alarm_cpu_threshold_percentage
   alarm_memory_threshold_percentage = var.alarm_memory_threshold_percentage

--- a/monitor.tf
+++ b/monitor.tf
@@ -464,7 +464,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "traces" {
   resource_group_name  = local.resource_group.name
   location             = local.resource_group.location
   evaluation_frequency = "PT5M"
-  window_duration      = "PT5M"
+  window_duration      = "PT15M"
   scopes               = [azurerm_application_insights.main[0].id]
   severity             = 2 # Warning
   description          = "Action will be triggered when ${local.enable_monitoring_traces_include_warnings ? "warnings or " : ""}errors are detected in App Insights traces"

--- a/monitor.tf
+++ b/monitor.tf
@@ -458,6 +458,68 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "exceptions" {
   tags = local.tags
 }
 
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "traces" {
+  count = local.enable_monitoring && local.enable_monitoring_traces && local.enable_app_insights_integration ? 1 : 0
+
+  name                 = "Error Count - ${azurerm_application_insights.main[0].name}"
+  resource_group_name  = local.resource_group.name
+  location             = local.resource_group.location
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT5M"
+  scopes               = [azurerm_application_insights.main[0].id]
+  severity             = 2 # Warning
+  description          = "Action will be triggered when ${local.enable_monitoring_traces_include_warnings ? "warnings or " : ""}errors are detected in App Insights traces"
+
+  criteria {
+    query = <<-QUERY
+      traces
+        | where
+            isempty(customDimensions.StatusCode) or
+            (isnotempty(customDimensions.StatusCode) and customDimensions.StatusCode >= 500)
+        | where isnotempty(operation_Name)
+        | where timestamp > ago(5m)
+        | where severityLevel >= ${local.enable_monitoring_traces_include_warnings ? 2 : 3}
+        | extend severity = case(
+            severityLevel == 4, "Fatal",
+            severityLevel == 3, "Error",
+            severityLevel == 2, "Warning",
+            "Unknown" // Default case
+        )
+        | project timestamp, operation_Name, message, severity
+        | order by timestamp desc
+      QUERY
+
+    time_aggregation_method = "Count"
+    threshold               = 1
+    operator                = "GreaterThanOrEqual"
+
+    dimension {
+      name     = "operation_Name"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "message"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  auto_mitigation_enabled = false
+
+  action {
+    action_groups = [azurerm_monitor_action_group.main[0].id]
+  }
+
+  tags = local.tags
+}
+
 resource "azurerm_monitor_metric_alert" "http" {
   count = local.enable_monitoring && local.enable_app_insights_integration ? 1 : 0
 

--- a/monitor.tf
+++ b/monitor.tf
@@ -484,7 +484,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "traces" {
             severityLevel == 2, "Warning",
             "Unknown" // Default case
         )
-        | project operation_Id, timestamp, host, operation_Name, message, severity
+        | join requests on $left.operation_Id == $right.operation_Id
+        | project operation_Id, timestamp, host, operation_Name, message, severity, url, resultCode
         | order by timestamp desc
       QUERY
 
@@ -518,6 +519,18 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "traces" {
 
     dimension {
       name     = "severity"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "url"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "resultCode"
       operator = "Include"
       values   = ["*"]
     }

--- a/monitor.tf
+++ b/monitor.tf
@@ -396,7 +396,6 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "exceptions" {
     query = <<-QUERY
       requests
         | where toint(resultCode) >= 500
-        | where timestamp > ago(5m)
         | join exceptions on operation_Id
         | project timestamp, itemId, name, url, type, outerMessage, appName,
             linkToAppInsights = strcat(
@@ -477,7 +476,6 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "traces" {
             isempty(customDimensions.StatusCode) or
             (isnotempty(customDimensions.StatusCode) and customDimensions.StatusCode >= 500)
         | where isnotempty(operation_Name)
-        | where timestamp > ago(5m)
         | where severityLevel >= ${local.enable_monitoring_traces_include_warnings ? 2 : 3}
         | extend severity = case(
             severityLevel == 4, "Fatal",

--- a/monitor.tf
+++ b/monitor.tf
@@ -505,6 +505,12 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "traces" {
       values   = ["*"]
     }
 
+    dimension {
+      name     = "severity"
+      operator = "Include"
+      values   = ["*"]
+    }
+
     failing_periods {
       minimum_failing_periods_to_trigger_alert = 1
       number_of_evaluation_periods             = 1

--- a/variables.tf
+++ b/variables.tf
@@ -1285,3 +1285,15 @@ variable "monitor_http_availability_verb" {
   type        = string
   default     = "HEAD"
 }
+
+variable "enable_monitoring_traces" {
+  description = "Monitor App Insights traces for error messages"
+  type        = bool
+  default     = false
+}
+
+variable "enable_monitoring_traces_include_warnings" {
+  description = "Extend the App Insights trace monitor to include warning messages (warning: could be noisy!)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Adds an new log query alert for App Insights so that we can toggle-on monitoring for Traces where the severity level is Error or greater, but including a second optional toggle for including Warnings too (they are especially noisy sometimes). This can be useful for developers for raising visibility of non-exception errors.