### PR TITLE
Cast type to boolean

### DIFF
--- a/functions/src/health-api/function_app.py
+++ b/functions/src/health-api/function_app.py
@@ -11,7 +11,7 @@ credential = DefaultAzureCredential()
 client = LogsQueryClient(credential)
 
 response_headers = { "Content-Type": "application/json" }
-query = """ availabilityResults | project location, success, timestamp | order by timestamp desc | take 3"""
+query = """ availabilityResults | project location, tobool(success), timestamp | order by timestamp desc | take 3"""
 
 app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
 
@@ -50,7 +50,11 @@ def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
 
             for table in data:
                 for row in table.rows:
-                    list.append(struct, {"location": row[0], "success": bool(row[1])})
+                    struct.append({
+                        "location": row[0],
+                        "success": bool(row[1]),
+                        "timestamp": str(row[2])
+                    })
 
             logging.info(struct)
 


### PR DESCRIPTION
* 'success' column was being interpreted as a string '0' and always being displayed by the Function App as boolean 'true' which is not indicative of the status. This change ensures the data queried in KQL is cast as a boolean early to normalise the data type