### PR TITLE
Migrate scope from NSG to VNET

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -516,18 +516,14 @@ locals {
   alarm_for_delete_events           = var.alarm_for_delete_events
 
   # Network Watcher
-  enable_network_watcher                         = var.enable_network_watcher
-  existing_network_watcher_name                  = var.existing_network_watcher_name
-  existing_network_watcher_resource_group_name   = var.existing_network_watcher_resource_group_name
-  network_watcher_name                           = local.enable_network_watcher ? azurerm_network_watcher.default[0].name : local.existing_network_watcher_name
-  network_watcher_resource_group_name            = local.network_watcher_name != "" ? local.existing_network_watcher_resource_group_name : local.resource_group.name
-  network_watcher_flow_log_retention             = var.network_watcher_flow_log_retention
-  enable_network_watcher_traffic_analytics       = var.enable_network_watcher_traffic_analytics
-  network_watcher_traffic_analytics_interval     = var.network_watcher_traffic_analytics_interval
-  network_security_group_container_apps_infra_id = local.launch_in_vnet ? { "container_apps_infra" = azurerm_network_security_group.container_apps_infra[0].id } : {}
-  network_security_group_ids = merge(
-    local.network_security_group_container_apps_infra_id,
-  )
+  enable_network_watcher                                        = var.enable_network_watcher
+  existing_network_watcher_name                                 = var.existing_network_watcher_name
+  existing_network_watcher_resource_group_name                  = var.existing_network_watcher_resource_group_name
+  network_watcher_name                                          = local.enable_network_watcher ? azurerm_network_watcher.default[0].name : local.existing_network_watcher_name
+  network_watcher_resource_group_name                           = local.network_watcher_name != "" ? local.existing_network_watcher_resource_group_name : local.resource_group.name
+  network_watcher_flow_log_retention                            = var.network_watcher_flow_log_retention
+  enable_network_watcher_traffic_analytics                      = var.enable_network_watcher_traffic_analytics
+  network_watcher_traffic_analytics_interval                    = var.network_watcher_traffic_analytics_interval
   network_watcher_nsg_storage_access_key_rotation_reminder_days = var.network_watcher_nsg_storage_access_key_rotation_reminder_days != 0 ? var.network_watcher_nsg_storage_access_key_rotation_reminder_days : local.storage_account_access_key_rotation_reminder_days
 
   # App Configuration

--- a/network-watcher.tf
+++ b/network-watcher.tf
@@ -70,15 +70,15 @@ resource "azurerm_log_analytics_workspace" "default_network_watcher_nsg_flow_log
 }
 
 resource "azurerm_network_watcher_flow_log" "default_network_watcher_nsg" {
-  for_each = local.network_watcher_name != "" ? local.network_security_group_ids : {}
+  count = local.network_watcher_name != "" ? 1 : 0
 
   network_watcher_name = local.network_watcher_name
   resource_group_name  = local.network_watcher_resource_group_name
-  name                 = "${local.resource_prefix}nsg${element(split("/", each.value), length(split("/", each.value)) - 1)}"
+  name                 = "${local.resource_prefix}nsg${local.virtual_network.name}"
 
-  network_security_group_id = each.value
-  storage_account_id        = azurerm_storage_account.default_network_watcher_nsg_flow_logs[0].id
-  enabled                   = true
+  target_resource_id = local.virtual_network.id
+  storage_account_id = azurerm_storage_account.default_network_watcher_nsg_flow_logs[0].id
+  enabled            = true
 
   retention_policy {
     enabled = local.network_watcher_flow_log_retention == 0 ? false : true


### PR DESCRIPTION
>On 30 September 2027, Network security group (NSG) flow logs in Azure Network Watcher will be retired. As part of this retirement, you'll no longer be able to create new NSG flow logs starting 30 June 2025. To avoid service disruptions, migrate to virtual network flow logs by 30 September 2027