### PR TITLE
Switch to dynamic criteria for replica count alarm

### DIFF
--- a/monitor.tf
+++ b/monitor.tf
@@ -100,17 +100,17 @@ resource "azurerm_monitor_metric_alert" "count" {
   name                = "Container App Replica Count - ${each.value.name}"
   resource_group_name = local.resource_group.name
   scopes              = [each.value.id]
-  description         = "Container App ${each.value.name} has less than ${each.value.template[0].min_replicas} replicas"
+  description         = "Container App ${each.value.name} average replica count is less than the expected average"
   window_size         = "PT5M"
   frequency           = "PT1M"
   severity            = 1 # Error
 
-  criteria {
-    metric_namespace = "microsoft.app/containerapps"
-    metric_name      = "Replicas"
-    aggregation      = "Average"
-    operator         = "LessThan"
-    threshold        = each.value.template[0].min_replicas
+  dynamic_criteria {
+    metric_namespace  = "microsoft.app/containerapps"
+    metric_name       = "Replicas"
+    aggregation       = "Average"
+    operator          = "LessThan"
+    alert_sensitivity = "Medium"
   }
 
   action {


### PR DESCRIPTION
 * The metric alert commonly alarms during a container replica provisioning event which causes false positives due to the emitter not having any data for the new replica. Switching to a dynamic criteria means it will test against a common sliding average value across all replicas. Therefore container replica provisioning will be less likely to trigger the alarm
 
**Before:**
<img width="1551" alt="Screenshot 2025-04-14 at 11 27 37 am" src="https://github.com/user-attachments/assets/c3e423d7-9c07-43bc-b20d-1bfbc8c7b5a0" />

**After:**
<img width="1541" alt="Screenshot 2025-04-14 at 11 27 46 am" src="https://github.com/user-attachments/assets/471ea6f2-d548-4250-9f8d-bb47f91730e5" />
