### PR TITLE
Deny all egress within the VNET

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,6 +935,7 @@ module "azure_container_apps_hosting" {
 | <a name="input_storage_subnet_cidr"></a> [storage\_subnet\_cidr](#input\_storage\_subnet\_cidr) | Specify a subnet prefix to use for the storage subnet | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | `{}` | no |
 | <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space) | Virtual Network address space CIDR | `string` | `"172.16.0.0/12"` | no |
+| <a name="input_virtual_network_deny_all_egress"></a> [virtual\_network\_deny\_all\_egress](#input\_virtual\_network\_deny\_all\_egress) | Should all outbound traffic across the default Virtual Network be denied? | `bool` | `false` | no |
 | <a name="input_worker_container_command"></a> [worker\_container\_command](#input\_worker\_container\_command) | Container command for the Worker container. `enable_worker_container` must be set to true for this to have any effect. | `list(string)` | `[]` | no |
 | <a name="input_worker_container_max_replicas"></a> [worker\_container\_max\_replicas](#input\_worker\_container\_max\_replicas) | Worker ontainer max replicas | `number` | `2` | no |
 | <a name="input_worker_container_min_replicas"></a> [worker\_container\_min\_replicas](#input\_worker\_container\_min\_replicas) | Worker container min replicas | `number` | `1` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -24,6 +24,7 @@ locals {
   launch_in_vnet                                           = var.launch_in_vnet
   existing_virtual_network                                 = var.existing_virtual_network
   virtual_network                                          = local.existing_virtual_network == "" ? azurerm_virtual_network.default[0] : data.azurerm_virtual_network.existing_virtual_network[0]
+  virtual_network_deny_all_egress                          = var.virtual_network_deny_all_egress
   virtual_network_address_space                            = var.virtual_network_address_space
   virtual_network_address_space_mask                       = element(split("/", local.virtual_network_address_space), 1)
   container_apps_infra_subnet_cidr                         = var.container_apps_infra_subnet_cidr == "" ? cidrsubnet(local.virtual_network_address_space, 23 - local.virtual_network_address_space_mask, 0) : var.container_apps_infra_subnet_cidr

--- a/variables.tf
+++ b/variables.tf
@@ -1345,3 +1345,9 @@ variable "app_configuration_subnet_cidr" {
   type        = string
   default     = ""
 }
+
+variable "virtual_network_deny_all_egress" {
+  description = "Should all outbound traffic across the default Virtual Network be denied?"
+  type        = bool
+  default     = false
+}

--- a/virtual-network.tf
+++ b/virtual-network.tf
@@ -17,7 +17,18 @@ resource "azurerm_route_table" "default" {
   location                      = local.resource_group.location
   resource_group_name           = local.resource_group.name
   bgp_route_propagation_enabled = true
-  tags                          = local.tags
+
+  dynamic "route" {
+    for_each = local.virtual_network_deny_all_egress ? [1] : []
+
+    content {
+      name           = "deny-all-egress"
+      address_prefix = "0.0.0.0/0"
+      next_hop_type  = "None"
+    }
+  }
+
+  tags = local.tags
 }
 
 # Container App Networking


### PR DESCRIPTION
* Provides people with the option to blackhole all outgoing traffic. Useful when your subnets are expected to only connect over Private Endpoints and not to any external services