### PR TITLE
Register private DNS zone and link to existing AGW to enable private …

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,8 @@ module "azure_container_apps_hosting" {
 | [azurerm_postgresql_flexible_server_database.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_database) | resource |
 | [azurerm_postgresql_flexible_server_firewall_rule.firewall_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_firewall_rule) | resource |
 | [azurerm_private_dns_a_record.app_configuration_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
+| [azurerm_private_dns_a_record.container_app_environment_root](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
+| [azurerm_private_dns_a_record.container_app_environment_wildcard](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_dns_a_record.mssql_private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_dns_a_record.postgresql_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_dns_a_record.redis_cache_private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
@@ -688,6 +690,7 @@ module "azure_container_apps_hosting" {
 | [azurerm_private_dns_a_record.storage_private_link_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_dns_a_record.storage_private_link_file](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_dns_zone.app_configuration_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone.container_app_environment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone.mssql_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone.postgresql_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone.redis_cache_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
@@ -695,6 +698,7 @@ module "azure_container_apps_hosting" {
 | [azurerm_private_dns_zone.storage_private_link_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone.storage_private_link_file](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.app_configuration_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.container_app_environment_agw_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.mssql_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.postgresql_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.redis_cache_private_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
@@ -749,6 +753,7 @@ module "azure_container_apps_hosting" {
 | [azurerm_user_assigned_identity.function_apps](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.mssql](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [azurerm_virtual_network.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
+| [azurerm_virtual_network_peering.peered_vnet_app_gateway](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [terraform_data.function_app_package_sha](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [archive_file.azure_function](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [azapi_resource_action.existing_logic_app_workflow_callback_url](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource_action) | data source |
@@ -760,6 +765,7 @@ module "azure_container_apps_hosting" {
 | [azurerm_resource_group.existing_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_storage_account_blob_container_sas.container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account_blob_container_sas) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
+| [azurerm_virtual_network.existing_agw_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 | [azurerm_virtual_network.existing_virtual_network](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 
 ## Inputs
@@ -816,7 +822,7 @@ module "azure_container_apps_hosting" {
 | <a name="input_container_app_storage_account_shared_access_key_enabled"></a> [container\_app\_storage\_account\_shared\_access\_key\_enabled](#input\_container\_app\_storage\_account\_shared\_access\_key\_enabled) | Should the storage account for the container app permit requests to be authorized with the account access key via Shared Key? | `bool` | `true` | no |
 | <a name="input_container_app_storage_cross_tenant_replication_enabled"></a> [container\_app\_storage\_cross\_tenant\_replication\_enabled](#input\_container\_app\_storage\_cross\_tenant\_replication\_enabled) | Should cross Tenant replication be enabled? | `bool` | `false` | no |
 | <a name="input_container_app_use_managed_identity"></a> [container\_app\_use\_managed\_identity](#input\_container\_app\_use\_managed\_identity) | Deploy a User Assigned Managed Identity and attach it to the Container App | `bool` | `true` | no |
-| <a name="input_container_apps_allow_agw_resource"></a> [container\_apps\_allow\_agw\_resource](#input\_container\_apps\_allow\_agw\_resource) | Resource name and resource group of your App Gateway V2 resource | <pre>object({<br/>    name                = string<br/>    resource_group_name = string<br/>  })</pre> | <pre>{<br/>  "name": "",<br/>  "resource_group_name": ""<br/>}</pre> | no |
+| <a name="input_container_apps_allow_agw_resource"></a> [container\_apps\_allow\_agw\_resource](#input\_container\_apps\_allow\_agw\_resource) | Resource name and resource group of your App Gateway V2 resource | <pre>object({<br/>    name                = string<br/>    resource_group_name = string<br/>    vnet_name           = optional(string, "")<br/>  })</pre> | <pre>{<br/>  "name": "",<br/>  "resource_group_name": "",<br/>  "vnet_name": ""<br/>}</pre> | no |
 | <a name="input_container_apps_allow_ips_inbound"></a> [container\_apps\_allow\_ips\_inbound](#input\_container\_apps\_allow\_ips\_inbound) | Restricts access to the Container Apps by creating a network security group rule that only allow inbound traffic from the provided list of IPs | `list(string)` | `[]` | no |
 | <a name="input_container_apps_infra_subnet_cidr"></a> [container\_apps\_infra\_subnet\_cidr](#input\_container\_apps\_infra\_subnet\_cidr) | Specify a subnet prefix to use for the container\_apps\_infra subnet | `string` | `""` | no |
 | <a name="input_container_apps_infra_subnet_service_endpoints"></a> [container\_apps\_infra\_subnet\_service\_endpoints](#input\_container\_apps\_infra\_subnet\_service\_endpoints) | Endpoints to assign to infra subnet | `list(string)` | `[]` | no |

--- a/data.tf
+++ b/data.tf
@@ -66,6 +66,13 @@ data "azurerm_application_gateway" "existing_agw" {
   resource_group_name = local.container_apps_allow_agw_resource.resource_group_name
 }
 
+data "azurerm_virtual_network" "existing_agw_vnet" {
+  count = local.launch_in_vnet && local.restrict_container_apps_to_agw_inbound_only && local.container_apps_allow_agw_resource.vnet_name != "" ? 1 : 0
+
+  name                = local.container_apps_allow_agw_resource.vnet_name
+  resource_group_name = local.container_apps_allow_agw_resource.resource_group_name
+}
+
 data "azurerm_public_ip" "existing_agw_ip" {
   count = local.container_apps_allow_agw_pip_resource_id != null ? 1 : 0
 

--- a/locals.tf
+++ b/locals.tf
@@ -457,7 +457,7 @@ locals {
   restrict_container_apps_to_agw_inbound_only     = var.restrict_container_apps_to_agw_inbound_only
   container_apps_allow_agw_resource               = var.container_apps_allow_agw_resource
   container_apps_allow_agw_pip_resource_id        = length(data.azurerm_application_gateway.existing_agw) > 0 ? split("/", data.azurerm_application_gateway.existing_agw[0].frontend_ip_configuration[0].public_ip_address_id) : null
-  container_apps_allow_agw_ip                     = length(data.azurerm_application_gateway.existing_agw) > 0 ? data.azurerm_public_ip.existing_agw_ip[0].ip_address : null
+  container_apps_allow_agw_ip                     = length(data.azurerm_application_gateway.existing_agw) > 0 ? data.azurerm_public_ip.existing_agw_ip[0].ip_address : ""
   container_apps_allow_ips_inbound                = var.container_apps_allow_ips_inbound
   cdn_frontdoor_host_redirects                    = var.cdn_frontdoor_host_redirects
   cdn_frontdoor_host_add_response_headers         = var.cdn_frontdoor_host_add_response_headers

--- a/variables.tf
+++ b/variables.tf
@@ -1381,9 +1381,11 @@ variable "container_apps_allow_agw_resource" {
   type = object({
     name                = string
     resource_group_name = string
+    vnet_name           = optional(string, "")
   })
   default = {
     name                = ""
     resource_group_name = ""
+    vnet_name           = ""
   }
 }


### PR DESCRIPTION
…connection

* If an existing AGW VNET is included as a config parameter, automatically create a Private DNS Zone for the Container App Environment, and link it to the App Gateway Virtual Network