### PR TITLE
Fix: Only associate route table if not using Consumption profile

### DIFF
--- a/virtual-network.tf
+++ b/virtual-network.tf
@@ -218,7 +218,7 @@ resource "azurerm_subnet" "mssql_private_endpoint_subnet" {
 }
 
 resource "azurerm_subnet_route_table_association" "mssql_private_endpoint_subnet" {
-  count = local.enable_private_endpoint_mssql && local.existing_virtual_network == "" ? 1 : 0
+  count = local.enable_private_endpoint_mssql && local.existing_virtual_network == "" && local.container_app_environment_workload_profile_type != "Consumption" ? 1 : 0
 
   subnet_id      = azurerm_subnet.mssql_private_endpoint_subnet[0].id
   route_table_id = azurerm_route_table.default[0].id
@@ -309,7 +309,7 @@ resource "azurerm_subnet" "redis_cache_subnet" {
 }
 
 resource "azurerm_subnet_route_table_association" "redis_cache_subnet" {
-  count = local.enable_private_endpoint_redis && local.existing_virtual_network == "" ? 1 : 0
+  count = local.enable_private_endpoint_redis && local.existing_virtual_network == "" && local.container_app_environment_workload_profile_type != "Consumption" ? 1 : 0
 
   subnet_id      = azurerm_subnet.redis_cache_subnet[0].id
   route_table_id = azurerm_route_table.default[0].id
@@ -405,7 +405,7 @@ resource "azurerm_subnet" "postgresql_subnet" {
 }
 
 resource "azurerm_subnet_route_table_association" "postgresql_subnet" {
-  count = local.enable_private_endpoint_postgres && local.existing_virtual_network == "" ? 1 : 0
+  count = local.enable_private_endpoint_postgres && local.existing_virtual_network == "" && local.container_app_environment_workload_profile_type != "Consumption" ? 1 : 0
 
   subnet_id      = azurerm_subnet.postgresql_subnet[0].id
   route_table_id = azurerm_route_table.default[0].id
@@ -490,7 +490,7 @@ resource "azurerm_subnet" "registry_private_endpoint_subnet" {
 }
 
 resource "azurerm_subnet_route_table_association" "registry_private_endpoint_subnet" {
-  count = local.enable_private_endpoint_registry && local.existing_virtual_network == "" ? 1 : 0
+  count = local.enable_private_endpoint_registry && local.existing_virtual_network == "" && local.container_app_environment_workload_profile_type != "Consumption" ? 1 : 0
 
   subnet_id      = azurerm_subnet.registry_private_endpoint_subnet[0].id
   route_table_id = azurerm_route_table.default[0].id
@@ -575,7 +575,7 @@ resource "azurerm_subnet" "storage_private_endpoint_subnet" {
 }
 
 resource "azurerm_subnet_route_table_association" "storage_private_endpoint_subnet" {
-  count = local.enable_private_endpoint_storage && local.existing_virtual_network == "" ? 1 : 0
+  count = local.enable_private_endpoint_storage && local.existing_virtual_network == "" && local.container_app_environment_workload_profile_type != "Consumption" ? 1 : 0
 
   subnet_id      = azurerm_subnet.storage_private_endpoint_subnet[0].id
   route_table_id = azurerm_route_table.default[0].id
@@ -692,7 +692,7 @@ resource "azurerm_subnet" "app_configuration_private_endpoint_subnet" {
 }
 
 resource "azurerm_subnet_route_table_association" "app_configuration_private_endpoint_subnet" {
-  count = local.enable_private_endpoint_app_configuration && local.existing_virtual_network == "" ? 1 : 0
+  count = local.enable_private_endpoint_app_configuration && local.existing_virtual_network == "" && local.container_app_environment_workload_profile_type != "Consumption" ? 1 : 0
 
   subnet_id      = azurerm_subnet.app_configuration_private_endpoint_subnet[0].id
   route_table_id = azurerm_route_table.default[0].id


### PR DESCRIPTION
* The UDR is not deployed otherwise and it will cause invalid associations