### PR TITLE
SignalR resource group fix

### DIFF
--- a/signalr.tf
+++ b/signalr.tf
@@ -2,8 +2,8 @@ resource "azurerm_signalr_service" "default" {
   count = local.enable_signalr ? 1 : 0
 
   name                = "${local.resource_prefix}-signalr"
-  location            = azurerm_resource_group.default[0].location
-  resource_group_name = azurerm_resource_group.default[0].name
+  location            = local.resource_group.location
+  resource_group_name = local.resource_group.name
 
   sku {
     name     = local.signalr_sku


### PR DESCRIPTION
* When deploying into an existing resource group, the local variable needs to be used