### PR TITLE
feature: add output for environment id of container

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -65,3 +65,13 @@ output "container_app_environment_ingress_ip" {
   description = "Ingress IP address assigned to the Container App environment"
   value       = local.container_app_environment.static_ip_address
 }
+
+output "container_app_environment_id" {
+description = "Id of the used Container App environment - either existing or created"
+  value = (
+    local.existing_container_app_environment.name == ""
+    ? azurerm_container_app_environment.container_app_env[0].id
+    : data.azurerm_container_app_environment.existing_container_app_environment[0].id
+  )
+}
+


### PR DESCRIPTION
Add new output "container_app_environment_id"
which will be either the passed in container app environment or the created one

added as used in update to the waf shared module for front door private link